### PR TITLE
Enable pass-through of RRTMG compile option

### DIFF
--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # GEOSChem_GridComp/CMakeLists.txt
 
 set(GC_EXTERNAL_CONFIG      TRUE)
-set(RRTMG                   FALSE)
+set(RRTMG "OFF" CACHE BOOL "Switch to build RRTMG as a component of GEOS-Chem")
 set(GTMM                    FALSE)
 set(TOMAS                   FALSE)
 set(MECH                    "Standard") # for now, we only support "Standard"
@@ -13,7 +13,7 @@ add_subdirectory(geos-chem EXCLUDE_FROM_ALL)
 
 # Configure build properties for GEOS-Chem
 target_compile_definitions(GEOSChemBuildProperties INTERFACE
-        ESMF_ EXTERNAL_GRID USE_REAL8 NC_HAS_COMPRESSION BPCH_TBPC MODEL_GCHPCTM MODEL_GCHP
+        ESMF_ EXTERNAL_GRID USE_REAL8 NC_HAS_COMPRESSION BPCH_TBPC MODEL_GCHPCTM MODEL_GCHP $<$<BOOL:${RRTMG}>:RRTMG>
 )
 
 target_link_libraries(GEOSChemBuildProperties INTERFACE


### PR DESCRIPTION
If `-DRRTMG` is passed to the initial cmake call, this will now result in the appropriate calls being made during the compilation of the core GEOS-Chem model. This modification assumes that relevant modifications have been made in the GEOS-Chem repository.