### PR TITLE
Fixed make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,9 @@ list(APPEND CMAKE_MODULE_PATH
 )
 
 # Run directory
-set(RUNDIR ${CMAKE_BINARY_DIR}/.. CACHE PATH "Path to GCHPctm run directory")
-if(RUNDIR)
-  set(CMAKE_INSTALL_PREFIX ${RUNDIR} CACHE PATH "Install prefix for GCHPctm" FORCE)
-  set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
-endif()
+set(RUNDIR "" CACHE PATH "Path(s) to run directory (semicolon separated list). Specifies install locations for geos")
+set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Fake CMAKE_INSTALL_PREFIX (use RUNDIR instead)" FORCE)
+set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
 
 # Find nc-config and nf-config
 find_program(NC_CONFIG NAMES "nc-config" DOC "Location of nc-config utility")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,4 +37,6 @@ target_link_libraries(geos
 )
 set_target_properties(geos PROPERTIES
 	RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-install(TARGETS geos RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX})
+foreach(RUNDIR_PATH ${RUNDIR})
+	install(TARGETS geos RUNTIME DESTINATION ${RUNDIR_PATH})
+endforeach()


### PR DESCRIPTION
This change fixes `make install`. The "install" locations are controlled by the `RUNDIR` CMake variable. The behaviour is
- "install" (i.e. copy) location(s) for `geos` is controlled by `-DRUNDIR=` with CMake
- If `RUNDIR` is not empty (empty means "" which is its default value), then `geos` will be "installed" to each directory in `RUNDIR`
- `RUNDIR` can be empty ("" which is its default value), a single directory (relative or absolute), or multiple directories (relative or absolute, directories are semicolon separated as is standard for CMake)

Note that `CMAKE_PREFIX_PATH` is completely ignored now. This isn't ideal, but it cant be a list and so it doesn't work well for specifying run directories to install `geos` to (since someone might want to install `geos` to multiple run directories from a single build).