### PR TITLE
Release image and release pipeline

### DIFF
--- a/.ci-pipelines/release.dockerfile
+++ b/.ci-pipelines/release.dockerfile
@@ -31,7 +31,8 @@ RUN source /init.rc \
 
 RUN echo "#!/usr/bin/env bash" > /opt/geos-chem/bin/createRunDir.sh \
 &&  echo "cd /gc-src/run" >> /opt/geos-chem/bin/createRunDir.sh \
-&&  echo "bash createRunDir.sh" >> /opt/geos-chem/bin/createRunDir.sh
+&&  echo "bash createRunDir.sh" >> /opt/geos-chem/bin/createRunDir.sh \
+&&  chmod +x /opt/geos-chem/bin/createRunDir.sh
 
 RUN echo "#!/usr/bin/env bash" > /usr/bin/start-container.sh \
 &&  echo ". /init.rc" >> /usr/bin/start-container.sh \

--- a/.ci-pipelines/release.dockerfile
+++ b/.ci-pipelines/release.dockerfile
@@ -1,0 +1,40 @@
+FROM liambindle/penelope:2019.12-ubuntu16.04-openmpi4.0.1-esmf8.0.0
+
+# Make a directory to install GEOS-Chem to
+RUN mkdir -p /opt/geos-chem/bin
+
+# Copy the GCHP repository (".") to /gc-src
+# This means the docker build command context must be 
+# the root source code directory
+COPY . /gc-src
+RUN cd /gc-src \
+&&  mkdir build
+
+# Commands to properly set up the environment inside the container
+RUN echo "module load gcc/9" >> /init.rc \
+&&  echo "spack load openmpi" >> /init.rc \
+&&  echo "spack load hdf5" >> /init.rc \
+&&  echo "spack load netcdf-c" >> /init.rc \
+&&  echo "spack load netcdf-fortran" >> /init.rc \
+&&  echo "spack load esmf" >> /init.rc \
+&&  echo 'export PATH=$PATH:/opt/geos-chem/bin' >> /init.rc
+
+# Make bash the default shell
+SHELL ["/bin/bash", "-c"]
+
+# Build Standard and copy the executable to /opt/geos-chem/bin
+RUN source /init.rc \
+&&  cd /gc-src/build \
+&&  cmake  .. -DRUNDIR=/opt/geos-chem/bin -DCMAKE_COLOR_MAKEFILE=FALSE \
+&&  make -j install \
+&& rm -rf /gc-src/build
+
+RUN echo "#!/usr/bin/env bash" > /opt/geos-chem/bin/createRunDir.sh \
+&&  echo "cd /gc-src/run" >> /opt/geos-chem/bin/createRunDir.sh \
+&&  echo "bash createRunDir.sh" >> /opt/geos-chem/bin/createRunDir.sh
+
+RUN echo "#!/usr/bin/env bash" > /usr/bin/start-container.sh \
+&&  echo ". /init.rc" >> /usr/bin/start-container.sh \
+&&  echo 'if [ $# -gt 0 ]; then exec "$@"; else /bin/bash ; fi' >> /usr/bin/start-container.sh \
+&&  chmod +x /usr/bin/start-container.sh
+ENTRYPOINT ["start-container.sh"]

--- a/.ci-pipelines/release.yml
+++ b/.ci-pipelines/release.yml
@@ -1,0 +1,51 @@
+# Release pipeline:
+# 
+# This pipeline performs deployment actions upon a GEOS-Chem release.
+# Currently, the only deployment action is to build and push a docker 
+# container with GCHP for the newly released version.
+
+# This pipeline is triggered by tagged versions excluding 
+# pre-releases.
+trigger:
+  branches:
+    exclude:
+      - '*'
+  tags:
+    include:
+      - '*'
+    exclude:
+      - '*-alpha*'
+      - '*-beta*'
+      - '*-rc*'
+pr: none
+
+
+# Basic agent set up
+pool:
+  vmImage: 'ubuntu-latest'
+
+# Login to Docker Hub, build the image, and push the built image
+# to Docker Hub
+steps:
+  - script: VERSION_TAG=`git describe --tags` && echo "##vso[task.setvariable variable=VERSION_TAG]$VERSION_TAG"
+    displayName: Get the repo's tag
+  - task: Docker@2
+    displayName: Login to Docker Hub
+    inputs:
+      command: login
+      containerRegistry: DockerHub    # The name of the service connection in the Azure project
+  - task: Docker@2
+    displayName: Build image
+    inputs:
+      command: build
+      buildContext: $(Build.Repository.LocalPath)   # The path to the source code repo
+      Dockerfile: .ci-pipelines/release.dockerfile
+      repository: geoschemdev/gchp                  # Docker Hub repository
+      tags: $(VERSION_TAG)                          # Source code repo's tag
+  - task: Docker@2
+    displayName: Push image
+    inputs:
+      containerRegistry: DockerHub
+      repository: geoschemdev/gchp                  # Docker Hub repository
+      command: push
+      tags: $(VERSION_TAG)

--- a/.ci-pipelines/release.yml
+++ b/.ci-pipelines/release.yml
@@ -40,12 +40,12 @@ steps:
       command: build
       buildContext: $(Build.Repository.LocalPath)   # The path to the source code repo
       Dockerfile: .ci-pipelines/release.dockerfile
-      repository: geoschemdev/gchp                  # Docker Hub repository
+      repository: geoschem/gchp                     # Docker Hub repository
       tags: $(VERSION_TAG)                          # Source code repo's tag
   - task: Docker@2
     displayName: Push image
     inputs:
       containerRegistry: DockerHub
-      repository: geoschemdev/gchp                  # Docker Hub repository
+      repository: geoschem/gchp                     # Docker Hub repository
       command: push
       tags: $(VERSION_TAG)


### PR DESCRIPTION
This PR includes the CI configuration for building and deploying the pre-built GCHP image. This lets users that use **Docker or Singularity** try GCHP without needing to download the source code or compile. Proper documentation come on the RTD docs.

Executable in the `$PATH` by default (immediately when the user loads the environment):
- `gchp`: the GCHP executable
- `createRunDir.sh`: script that calls the actual `createRunDir.sh` in the source code

This image works for Docker and Singularity. The use case is
- Trying out/demoing GCHP
- For simulations on clusters that support Docker or Singularity for users that don't need maximum performance or to change the source code
  - Users that do want to modify the source code can use these images for an out-of-the-box fully-satisfied environment