### PR TITLE
Add runtime CI test

### DIFF
--- a/.ci-pipelines/quick-build.yml
+++ b/.ci-pipelines/quick-build.yml
@@ -42,7 +42,7 @@ steps:
     mkdir build
     cd build
     cmake $(Build.Repository.LocalPath) -DCMAKE_COLOR_MAKEFILE=FALSE -DRUNDIR=$(Build.Repository.LocalPath)/.ci-pipelines/MinimumStandaloneTransportTracer
-    make -j gchp
+    make -j install
   displayName: 'Build GCHP'
 - script: |
     source /init.rc

--- a/.ci-pipelines/quick-build.yml
+++ b/.ci-pipelines/quick-build.yml
@@ -1,15 +1,12 @@
 # Quick build pipeline:
 # 
-# This pipeline checks that commits and open pull requests don't 
-# introduce compiler errors. This is meant to be a quick and simple 
-# check that runs frequently.
+# This pipeline checks that commits and pull requests don't introduce build errors or runtime
+# errors. This is meant to be a quick and simple check that runs frequently.
 
 
-# This pipeline triggers on commits to development and bug-fix 
-# branches. Commits to the main branch do not trigger this pipeline
-# because those are tested against the build matrix. Commits to 
-# feature branches do not trigger this pipeline, but open pull requests
-# and commits to pull requests do.
+# This pipeline triggers on commits to development and bug-fix branches. Commits to the main branch
+# do not trigger this pipeline because those are tested by the build matrix. Commits to feature
+# branches do not trigger this pipeline, but pull requests and commits to pull requests do.
 trigger:
   branches:
     include:
@@ -30,7 +27,7 @@ container: liambindle/penelope:2019.12-centos7-openmpi3.1.4-esmf8.0.0
 # Try building GEOS-Chem
 steps:
 - checkout: self
-  submodules: true
+  submodules: recursive
 - script: |
     source /init.rc
     module load gcc/8
@@ -42,9 +39,21 @@ steps:
     spack load netcdf-c
     spack load netcdf-fortran
     spack load esmf
-    git -c $(Build.Repository.LocalPath) submodule update --init --recursive
     mkdir build
     cd build
-    cmake -DCMAKE_COLOR_MAKEFILE=FALSE $(Build.Repository.LocalPath)
+    cmake $(Build.Repository.LocalPath) -DCMAKE_COLOR_MAKEFILE=FALSE -DRUNDIR=$(Build.Repository.LocalPath)/.ci-pipelines/MinimumStandaloneTransportTracer
     make -j gchp
-  displayName: 'Building GCHP'
+  displayName: 'Build GCHP'
+- script: |
+    source /init.rc
+    module load gcc/8
+    spack load openmpi
+    spack load hdf5 
+    spack load netcdf-c
+    spack load netcdf-fortran
+    spack load esmf
+    cd $(Build.Repository.LocalPath)/.ci-pipelines/MinimumStandaloneTransportTracer
+    export OMPI_MCA_btl_vader_single_copy_mechanism=none
+    mpirun --oversubscribe -np 6 ./gchp
+    test -f OutputDir/GCHP.SpeciesConc.*.nc4
+  displayName: 'Run GCHP'

--- a/.ci-pipelines/quick-test.yml
+++ b/.ci-pipelines/quick-test.yml
@@ -1,4 +1,4 @@
-# Quick build pipeline:
+# Quick test pipeline:
 # 
 # This pipeline checks that commits and pull requests don't introduce build errors or runtime
 # errors. This is meant to be a quick and simple check that runs frequently.
@@ -24,7 +24,7 @@ pool:
 container: liambindle/penelope:2019.12-centos7-openmpi3.1.4-esmf8.0.0
 
 
-# Try building GEOS-Chem
+# Pipeline definition
 steps:
 - checkout: self
   submodules: recursive

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "docs/geos-chem-shared-docs"]
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git
+[submodule ".ci-pipelines/MinimumStandaloneTransportTracer"]
+	path = .ci-pipelines/MinimumStandaloneTransportTracer
+	url = https://github.com/geoschem/MinimumStandaloneTransportTracer.git


### PR DESCRIPTION
- Adds [geoschem/MinimumStandaloneTransportTracer](https://github.com/geoschem/MinimumStandaloneTransportTracer/tree/main) as a submodule
- "Quick Build" -> "Quick Test"
- Pushes to `dev/*`, `bugfix/*`, and PRs trigger this pipeline
- The runtime test is a C6 transport tracer simulation with all emissions zeroed out