### PR TITLE
Fixes #120: LUO_WETDEP build option works now 

### DIFF
--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -80,10 +80,14 @@ target_compile_options(GEOSChemBuildProperties
    >
 )
 
+#---------------------------------------------------------------------
+# Assign preprocessor definitions
+#---------------------------------------------------------------------
 target_compile_definitions(GEOSChemBuildProperties
     INTERFACE
     $<$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},Intel>:LINUX_IFORT>
     $<$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},GNU>:LINUX_GFORTRAN>
+    $<$<BOOL:${LUO_WETDEP}>:LUO_WETDEP>
 )
 
 # Print the options that are turned on in GEOS-Chem


### PR DESCRIPTION
Fixes #120

- [x] Tested that `-DLUO_WETDEP=ON` and `-DLUO_WETDEP=OFF` enables/disables the `LUO_WETDEP` preprocessor definition in the geos-chem submodule. 