### PR TITLE
Use ESMF_LOGKIND_MULTI_ON_ERROR for logging ESMF errors

### DIFF
--- a/src/GCHPctm.F90
+++ b/src/GCHPctm.F90
@@ -11,7 +11,7 @@
 #include "MAPL_Generic.h"
 
 Program GCHPctm_Main
-
+   use ESMF, only: ESMF_LOGKIND_MULTI_ON_ERROR
    use MAPL
    use GCHP_GridCompMod, only:  ROOT_SetServices => SetServices
 
@@ -26,6 +26,7 @@ Program GCHPctm_Main
 
    cap_options = MAPL_CapOptions(cap_rc_file='CAP.rc')
    cap_options%logging_config = 'logging.yml'
+   cap_options%esmf_logging_mode = ESMF_LOGKIND_MULTI_ON_ERROR
    cap = MAPL_CAP('GCHP', ROOT_SetServices, cap_options=cap_options)
    call cap%run(_RC)
    _VERIFY(status)


### PR DESCRIPTION
GEOS sets `cap_options%esmf_logging_mode` via FLAP. Since we don't use FLAP we get the default value of `ESMF_LOGKIND_NONE`. IIUC this means ESMF errors dont' get logged anywhere. I'm not exactly sure whether we will ever get any ESMF errors, but `ESMF_LOGKIND_MULTI_ON_ERROR` seems like a more reasonable default then `ESMF_LOGKIND_NONE`. The "multi on error" means that each PET will dump errors to a PETXX file only if an error happens. If no error happens there are not PET* files. 

I came across this option when I was troubleshooting #134. I was wondering why the `ESMF_ConfigGetAttribute()` call wasn't reporting a useful error message. It turns out that was something else, but I figured I should update this default setting anyway in the hopes it will aid in improving error messages. 

**Related**
* https://github.com/GEOS-ESM/MAPL/issues/992