### PR TITLE
Add EXE_FILE_NAME and INSTALLCOPY to src/CMakeLists.txt to facilitate integration testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This file documents all notable changes to the GCHP wrapper repository since ver
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add `EXE_FILE_NAME` and `INSTALLCOPY` to src/CMakeLists.txt (facilitates integration testing)
+
 ## [Unreleased 14.1.0]
 ### Changed
 - Updated GEOS-Chem submodule to 14.1.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,19 +32,70 @@ add_subdirectory(FMS fms_r8 EXCLUDE_FROM_ALL)
 # Add GCHP_GridComp
 add_subdirectory(GCHP_GridComp EXCLUDE_FROM_ALL)
 
-# The executable
-add_executable(gchp
-    GCHPctm.F90
+#-----------------------------------------------------------------------------
+# Define the GCHP executable:
+# 1. Specify a cache variable with the default target name
+# 2. Specify the location of the main program
+# 3. Specify libraries that the main program depends on
+# 4. Store the binary exectuable file in the bin folder (pre-install)
+#
+# The default file name will be "gchp".  If a name is specified at
+# configuration time with -DEXE_FILE_NAME, then that will be used instead.
+#-----------------------------------------------------------------------------
+set(EXE_FILE_NAME gchp CACHE STRING
+  "Default name for the GCHP executable file")
+mark_as_advanced(EXE_FILE_NAME)
+
+add_executable(${EXE_FILE_NAME}
+  GCHPctm.F90
 )
-target_link_libraries(gchp
-	PUBLIC GCHP_GridComp ${CMAKE_DL_LIBS}
+target_link_libraries(${EXE_FILE_NAME}
+  PUBLIC
+  GCHP_GridComp
+  ${CMAKE_DL_LIBS}
 )
-set_target_properties(gchp PROPERTIES
-	RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-foreach(RUNDIR_PATH ${RUNDIR})
-	# If RUNDIR is not a relative path, make it an absolute path relative to the build directory
-	if(NOT IS_ABSOLUTE "${RUNDIR_PATH}")
-		get_filename_component(RUNDIR_PATH "${RUNDIR_PATH}" ABSOLUTE BASE_DIR "${CMAKE_BINARY_DIR}")
-	endif()
-	install(TARGETS gchp RUNTIME DESTINATION ${RUNDIR_PATH})
+set_target_properties(${EXE_FILE_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+#-----------------------------------------------------------------------------
+# Allow GCHP to be installed either to the path specified by -DRUNDIR or
+# -DINSTALLCOPY.  In most instances, the build directory is a subdirectory
+# of the run directory, so -DRUNDIR=.. will install the executable in the run
+# directory.  Using -DINSTALLCOPY allows you to specify an arbitrary folder
+# where the executable file wll be placed.  This facilitates automatic
+# testing (such as integration testing).
+#-----------------------------------------------------------------------------
+
+# Define set of installation paths to consider
+set(COMBINED_INSTALL_DIRS "")
+list(APPEND COMBINED_INSTALL_DIRS ${RUNDIR})
+list(APPEND COMBINED_INSTALL_DIRS ${INSTALLCOPY})
+
+# Consider installation to all of the specified paths
+foreach(INSTALL_PATH ${COMBINED_INSTALL_DIRS})
+    if(INSTALL_PATH IN_LIST RUNDIR)
+        set(CHECK_IS_RUNDIR TRUE)
+    else()
+        set(CHECK_IS_RUNDIR FALSE)
+    endif()
+
+    # Convert INSTALL_PATH to absolute
+    if(NOT IS_ABSOLUTE "${INSTALL_PATH}")
+      get_filename_component(INSTALL_PATH "${INSTALL_PATH}" ABSOLUTE BASE_DIR "${CMAKE_BINARY_DIR}")
+    endif()
+
+    # Issue warning and skip if geoschem_config.yml doesn't exist
+    # (i.e. if it doens't look like a run directory)
+    if(CHECK_IS_RUNDIR AND (NOT EXISTS ${INSTALL_PATH}/geoschem_config.yml))
+      # Installation path is not a GEOS-Chem run directory
+      # Skip ahead -- a warning will be raised elsewhere.
+      continue()
+    else()
+      # Installation path is a GEOS-Chem run directory,
+      # Therefore we will install the executable there.
+      install(TARGETS ${EXE_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
+    endif()
+
 endforeach()


### PR DESCRIPTION
This PR modifies the `src/CMakeLists.txt` so that:
1. The GCHP executable file can be assigned a name other than "gchp" (e.g. `-DEXE_FILE_NAME=gchp.rrtmg`)
2. The GCHP executable file can be placed in a folder other than the run directory
(e.g. `-DRUNDIR='' -DINSTALLCOPY=/path/to/installation`)
These features are already present in GEOS-Chem Classic, but are also needed in GCHP to facilitate integration testing.

Also updated the `CHANGELOG.md` accordingly.

This PR should be merged concurrently with https://github.com/geoschem/geos-chem/pull/1565

GCHP integration tests are in progress.