### PR TITLE
Fix several problems with Github template issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GCHP user manual
+    url: https://gchp.readthedocs.io/en/stable
+    about: Click this link to read the GCHP user manual.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
----
-name: Submit updates to the GCHP superproject with a pull request
-labels: 'never stale'
-
----
-
 ### Name and Institution (Required)
 
 Name:


### PR DESCRIPTION
This PR fixes some problems with the GitHub issue and PR templates.  Namely:

1. The PR template is now `.github/PULL_REQUEST_TEMPLATE.md`
2. Added `.github/ISSUE_TEMPLATE/config.yml` to prevent blank issues and add a link to the GC manual at RTD.

This is a zero-diff update, as only code in the `.github` folder was touched.