### PR TITLE
Make FindESMF.cmake use consistent libs

### DIFF
--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -135,7 +135,7 @@ find_package(NetCDF REQUIRED)
 find_package(MPI REQUIRED)
 execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libstdc++.so OUTPUT_VARIABLE stdcxx OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process (COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libgcc.a OUTPUT_VARIABLE libgcc OUTPUT_STRIP_TRAILING_WHITESPACE)
-set(ESMF_LIBRARIES ${ESMF_LIBRARY} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_CXX_LIBRARIES} rt ${stdcxx} ${libgcc})
+set(ESMF_LIBRARIES ${ESMF_LIBRARY} ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_CXX_LIBRARIES} rt dl ${stdcxx} ${libgcc})
 set(ESMF_INCLUDE_DIRS ${ESMF_HEADERS_DIR} ${ESMF_MOD_DIR})
 
 # Check if ESMF is built with OpenMP. If so, link OpenMP
@@ -167,9 +167,7 @@ if(NOT TARGET esmf)
 	)
 	target_link_libraries(esmf 
 		INTERFACE 
-			${NETCDF_LIBRARIES} 
-			${MPI_Fortran_LIBRARIES} ${MPI_CXX_LIBRARIES} 
-			rt ${stdcxx} ${libgcc}
+			${ESMF_LIBRARIES}
 	)
 	target_include_directories(esmf INTERFACE ${ESMF_INCLUDE_DIRS})
 	add_library(ESMF ALIAS esmf)


### PR DESCRIPTION
In `FindESMF.cmake` we spend a lot of time and effort defining the `ESMF_LIBRARIES` variable, including bringing in common libraries such as netCDF, MPI, and so on. However, we then hand-specify these later on for linking with ESMF. This patch makes two edits:

1. It includes the `dl` library; and
2. It uses the `ESMF_LIBRARIES` variable at the end instead of re-specifying all of them again (which was causing libraries like `PIO` to be missed and, on at least one system, also `dl`).

This change should be 100% benign (zero-diff) and fixes issue #305.

Name and institution: Seb Eastham, MIT.