### PR TITLE
Update symbolic link from GCHP root folder to the test folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 14.2.1]
+### Changed
+- `test` now points to `src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/test`
+
+
 ## [Unreleased 14.2.0]
 ### Fixed
   - Fixed post-advection pressure edges (PLE1) passed to advection to be derived from the correct surface pressure

--- a/test
+++ b/test
@@ -1,1 +1,1 @@
-src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/test/GCHP
+src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/test


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is a companion PR to https://github.com/geoschem/geos-chem/pull/1794.  This resets the `test` folder to the new path `src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/test` to be consistent with the changes made in the geoschem/geos-chem repo.

### Expected changes

This is a zero-diff update, as it only modifies a symbolic link.  No scientific changes are added.

### Reference(s)

N/A

### Related Github Issue(s)

- Merge after https://github.com/geoschem/geos-chem/pull/1794
- Fixes several issues in https://github.com/geoschem/geos-chem/issues/714
- The corresponding PR for GCClassic is https://github.com/geoschem/GCClassic/pull/41