### PR TITLE
Set ESMF logging option at run-time via config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 14.2.1]
 ### Changed
 - `test` now points to `src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/test`
-
+- Hard-coded ESMF logging option removed from GCHPctm.F90
 
 ## [Unreleased 14.2.0]
 ### Fixed

--- a/src/GCHPctm.F90
+++ b/src/GCHPctm.F90
@@ -11,7 +11,6 @@
 #include "MAPL_Generic.h"
 
 Program GCHPctm_Main
-   use ESMF, only: ESMF_LOGKIND_MULTI_ON_ERROR
    use MAPL
    use GCHP_GridCompMod, only:  ROOT_SetServices => SetServices
 
@@ -26,7 +25,6 @@ Program GCHPctm_Main
 
    cap_options = MAPL_CapOptions(cap_rc_file='CAP.rc')
    cap_options%logging_config = 'logging.yml'
-   cap_options%esmf_logging_mode = ESMF_LOGKIND_MULTI_ON_ERROR 
    cap = MAPL_CAP('GCHP', ROOT_SetServices, cap_options=cap_options)
    call cap%run(_RC)
    _VERIFY(status)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://gchp.readthedocs.io/en/latest/reference/CONTRIBUTING.html)

### Describe the update

This update includes a MAPL update developed by Matt Thompson (NASA GMAO). Previously the ESMF logging mode was hard-coded in the GCHP main program in `src/GCHPctm.F90`. Changing it required recompiling the model. With this update the logging option is instead specified in new config file `ESMF.rc` and can be changed at run-time.

The default ESMF logging option is also changed in this update, from `ESMF_LOGKIND_MULTI_ON_ERROR` to `ESMF_LOGKIND_NONE`.

### Expected changes

There is a new config file in GCHP run directories called ESMF.rc. By default a set of ESMF log files will no longer be created if an ESMF error is encountered.

### Reference(s)

None

### Related Github Issue(s)

- https://github.com/geoschem/GCHP/issues/304
- https://github.com/GEOS-ESM/MAPL/issues/2133

### Required Submodule Updates (to be merged at the same time)

- https://github.com/geoschem/MAPL/pull/29
- https://github.com/geoschem/geos-chem/pull/1879
