### PR TITLE
Avoid a semicolon in CMAKE_Fortran_FLAGS when additional flags are passed to `cmake`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ ecbuild_declare_project()
 find_package(MPI REQUIRED COMPONENTS C CXX Fortran)
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-  list(APPEND CMAKE_Fortran_FLAGS "-ffree-line-length-none")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
 endif()
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Simon Branford
Institution: University of Birmingham

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gchp.readthedocs.io/en/latest/reference/CONTRIBUTING.html)

### Describe the update

This fixes the setting of `CMAKE_Fortran_FLAGS` in the case where a user wishes to specify additional flags.

In #326 the extra flag was `-m64` for me it was `-march=native`.

```sh
git clone https://github.com/geoschem/GCHP.git
cd GCHP
git checkout 14.1.1
git submodule update --init --recursive
mkdir build & cd build
cmake -DCMAKE_Fortran_FLAGS="-march=native" ../
make VERBOSE=1
```

### Expected changes

GCHP to successfully build if there are extra flags passed to `cmake` via `CMAKE_Fortran_FLAGS`.

### Reference(s)

None

### Related Github Issue(s)

#326
