### PR TITLE
Update ESMF to 8.5.0

### DIFF
--- a/spack/packages.yaml
+++ b/spack/packages.yaml
@@ -14,7 +14,7 @@ packages:
     hdf5:
         variants: ~mpi
     esmf:
-        version: [8.0.1]
+        version: [8.5.0]
         variants: ~pio~pnetcdf~xerces
         compiler: [intel, gcc]
     netcdf-c:


### PR DESCRIPTION
For this reason: https://github.com/GEOS-ESM/MAPL/issues/1855

### Name and Institution (Required)

Name: Chris Tessum
Institution: UIUC

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://gchp.readthedocs.io/en/latest/reference/CONTRIBUTING.html)

### Describe the update

The problem is described here: https://github.com/GEOS-ESM/MAPL/issues/1855

The same location describes a change that can be made to the CMAKE config to catch the issue during build configuration for environments that do not use the included spack configuration: https://github.com/GEOS-ESM/MAPL/issues/1855#issuecomment-1344511880

### Expected changes

GCHP should compile with this change, whereas before the change it would not compile (for me). I have tested this on the UIUC campus cluster with gcc 12.2.0.

N.B. in order for it to successfully compile for me, I had to manually add libpioc.so and libpiof.so to the final link command. I don't know if this is related to the change in ESMF version or not, though.

### Reference(s)

None

### Related Github Issue(s)

https://github.com/GEOS-ESM/MAPL/issues/1855
