### PR TITLE
Add Cloud-J as submodule to GCHP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,5 +32,5 @@
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git
 [submodule "src/GCHP_GridComp/GEOSChem_GridComp/Cloud-J"]
-	path = src/GCHP_GridComp/GEOSChem_GridComp/Cloud-J
+	path = src/GCHP_GridComp/Cloud-J
 	url = https://github.com/geoschem/Cloud-J

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "docs/geos-chem-shared-docs"]
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git
+[submodule "src/GCHP_GridComp/GEOSChem_GridComp/Cloud-J"]
+	path = src/GCHP_GridComp/GEOSChem_GridComp/Cloud-J
+	url = https://github.com/geoschem/Cloud-J

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 14.3.0] - TBD
+### Added
+- Added Cloud-J as submodule within GCHP_GridComp directory
+
 ## [14.2.2] - 2023-10-23
 ### Changed
 - Updated GEOS-Chem submodule to 14.2.2

--- a/src/GCHP_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/CMakeLists.txt
@@ -3,16 +3,27 @@
 #---------------
 # Set cmake logicals needed for subprojects
 #---------------
-set(FV_PRECISION          R8    ) # FV3 precision is R8
-set(HEMCO_EXTERNAL_CONFIG TRUE  ) # Not HEMCO standalone
-set(GC_EXTERNAL_CONFIG    TRUE  ) # Not GEOS-Chem Classic
-set(MAPL_ESMF             TRUE  ) # HEMCO and GEOS-Chem will use MAPL/ESMF
+set(FV_PRECISION           R8    ) # FV3 precision is R8
+set(CLOUDJ_EXTERNAL_CONFIG TRUE  ) # Not Cloud-J standalone
+set(HEMCO_EXTERNAL_CONFIG  TRUE  ) # Not HEMCO standalone
+set(GC_EXTERNAL_CONFIG     TRUE  ) # Not GEOS-Chem Classic
+set(MAPL_ESMF              TRUE  ) # HEMCO and GEOS-Chem will use MAPL/ESMF
 set(MAPL_ACG ${CMAKE_CURRENT_SOURCE_DIR}/../MAPL/Apps/mapl_acg.pl)
+set(CLOUDJ OFF CACHE BOOL
+  "Switch to build the Cloud-J photolysis library"
+)
 
 #---------------
 # Add FV3
 #---------------
 add_subdirectory(FVdycoreCubed_GridComp EXCLUDE_FROM_ALL)
+
+#---------------
+# Add Cloud-J
+#---------------
+if(${CLOUDJ})
+  add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
+endif()
 
 #---------------
 # Add HEMCO

--- a/src/GCHP_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/CMakeLists.txt
@@ -9,9 +9,6 @@ set(HEMCO_EXTERNAL_CONFIG  TRUE  ) # Not HEMCO standalone
 set(GC_EXTERNAL_CONFIG     TRUE  ) # Not GEOS-Chem Classic
 set(MAPL_ESMF              TRUE  ) # HEMCO and GEOS-Chem will use MAPL/ESMF
 set(MAPL_ACG ${CMAKE_CURRENT_SOURCE_DIR}/../MAPL/Apps/mapl_acg.pl)
-set(CLOUDJ OFF CACHE BOOL
-  "Switch to build the Cloud-J photolysis library"
-)
 
 #---------------
 # Add FV3
@@ -21,9 +18,7 @@ add_subdirectory(FVdycoreCubed_GridComp EXCLUDE_FROM_ALL)
 #---------------
 # Add Cloud-J
 #---------------
-if(${CLOUDJ})
-  add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
-endif()
+add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
 
 #---------------
 # Add HEMCO

--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -10,6 +10,10 @@ set(RRTMG OFF CACHE BOOL
 set(LUO_WETDEP OFF CACHE BOOL
   "Switch to build the Luo et al (2020) wetdep scheme into GEOS-Chem"
 )
+set(CLOUDJ OFF CACHE BOOL
+  "Switch to build the Cloud-J photolysis library"
+)
+
 
 # Local variables
 set(GC_EXTERNAL_CONFIG      TRUE)
@@ -19,6 +23,11 @@ set(TOMAS                   FALSE)
 set(GCHP                    TRUE)
 set(MODEL_GCHP              TRUE)
 set(MODEL_GCHPCTM           TRUE)
+
+# Add directories to build
+if(${CLOUDJ})
+  add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
+endif()
 add_subdirectory(geos-chem EXCLUDE_FROM_ALL)
 
 # Configure build properties for GEOS-Chem
@@ -28,6 +37,7 @@ target_compile_definitions(GEOSChemBuildProperties INTERFACE
   $<$<BOOL:${ADJOINT}>:ADJOINT>
   $<$<BOOL:${REVERSE_OPERATORS}>:REVERSE_OPERATORS> 
   $<$<BOOL:${LUO_WETDEP}>:LUO_WETDEP>
+  $<$<BOOL:${CLOUDJ}>:CLOUDJ>
 )
 
 target_link_libraries(GEOSChemBuildProperties INTERFACE
@@ -128,3 +138,4 @@ gc_pretty_print(VARIABLE APM IS_BOOLEAN)
 gc_pretty_print(VARIABLE RRTMG IS_BOOLEAN)
 gc_pretty_print(VARIABLE GTMM IS_BOOLEAN)
 gc_pretty_print(VARIABLE LUO_WETDEP IS_BOOLEAN)
+gc_pretty_print(VARIABLE CLOUDJ IS_BOOLEAN)

--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -10,10 +10,6 @@ set(RRTMG OFF CACHE BOOL
 set(LUO_WETDEP OFF CACHE BOOL
   "Switch to build the Luo et al (2020) wetdep scheme into GEOS-Chem"
 )
-set(CLOUDJ OFF CACHE BOOL
-  "Switch to build the Cloud-J photolysis library"
-)
-
 
 # Local variables
 set(GC_EXTERNAL_CONFIG      TRUE)
@@ -25,9 +21,6 @@ set(MODEL_GCHP              TRUE)
 set(MODEL_GCHPCTM           TRUE)
 
 # Add directories to build
-if(${CLOUDJ})
-  add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
-endif()
 add_subdirectory(geos-chem EXCLUDE_FROM_ALL)
 
 # Configure build properties for GEOS-Chem

--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -10,6 +10,9 @@ set(RRTMG OFF CACHE BOOL
 set(LUO_WETDEP OFF CACHE BOOL
   "Switch to build the Luo et al (2020) wetdep scheme into GEOS-Chem"
 )
+set(FASTJX OFF CACHE BOOL
+  "Switch to use legacy FAST-JX photolysis in GEOS-Chem"
+)
 
 # Local variables
 set(GC_EXTERNAL_CONFIG      TRUE)
@@ -30,7 +33,7 @@ target_compile_definitions(GEOSChemBuildProperties INTERFACE
   $<$<BOOL:${ADJOINT}>:ADJOINT>
   $<$<BOOL:${REVERSE_OPERATORS}>:REVERSE_OPERATORS> 
   $<$<BOOL:${LUO_WETDEP}>:LUO_WETDEP>
-  $<$<BOOL:${CLOUDJ}>:CLOUDJ>
+  $<$<BOOL:${FASTJX}>:FASTJX>
 )
 
 target_link_libraries(GEOSChemBuildProperties INTERFACE
@@ -131,4 +134,4 @@ gc_pretty_print(VARIABLE APM IS_BOOLEAN)
 gc_pretty_print(VARIABLE RRTMG IS_BOOLEAN)
 gc_pretty_print(VARIABLE GTMM IS_BOOLEAN)
 gc_pretty_print(VARIABLE LUO_WETDEP IS_BOOLEAN)
-gc_pretty_print(VARIABLE CLOUDJ IS_BOOLEAN)
+gc_pretty_print(VARIABLE FASTJX IS_BOOLEAN)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update adds the [Cloud-J](https://github.com/geoschem/cloud-J/) photolysis library as a submodule with GCHP. It is stored alongside GEOS-Chem in `src/GCHP_GridComp/Chem_GridComp`. This PR should be merged with https://github.com/geoschem/geos-chem/pull/1522.

### Expected changes

See https://github.com/geoschem/geos-chem/pull/1522 for changes expected in GEOS-Chem when using Cloud-J to compute J-values.

### Reference(s)

Prather, M. J.: Photolysis rates in correlated overlapping cloud fields: Cloud-J 7.3c, Geosci. Model Dev., 8, 2587–2595, https://doi.org/10.5194/gmd-8-2587-2015, 2015.

### Related Github Issue(s)

https://github.com/geoschem/geos-chem/pull/1522