### PR TITLE
Include a utility script to change GCHP version numbers before release

### DIFF
--- a/.release/changeVersionNumbers.sh
+++ b/.release/changeVersionNumbers.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+#EOC
+#------------------------------------------------------------------------------
+#                  GEOS-Chem Global Chemical Transport Model                  !
+#------------------------------------------------------------------------------
+#BOP
+#
+# !MODULE: changeVersionNumbers.sh
+#
+# !DESCRIPTION: Bash script to change the version numbers in the appropriate
+#  files in the GCHP directory structure.  Run this before releasing
+#  a new GCHP Classic version.
+#\\
+#\\
+# !CALLING SEQUENCE:
+#  $ ./changeVersionNumbers.sh X.Y.Z        # X.Y.Z = GCHP version number
+#EOP
+#------------------------------------------------------------------------------
+#BOC
+
+function replace() {
+
+    #========================================================================
+    # Function to replace text in a file via sed.
+    #
+    # 1st argument: Search pattern
+    # 2nd argument: Replacement text
+    # 3rd argument: File in which to search and replace
+    #========================================================================
+
+    sed -i -e "s/${1}/${2}/" "${3}"
+}
+
+
+function exitWithError() {
+
+    #========================================================================
+    # Display and error message and exit
+    #========================================================================
+
+    echo "Could not update version numbers in ${1}... Exiting!"
+    exit 1
+}
+
+
+function main() {
+
+    #========================================================================
+    # Replaces the version number in the files listed.
+    #
+    # 1st argument: New version number to use
+    #========================================================================
+
+    # New version number
+    version="${1}"
+
+    # Save this directory path and change to root directory
+    thisDir=$(pwd -P)
+    cd ..
+
+    #========================================================================
+    # Update version numbers in various files
+    #========================================================================
+
+    # Pattern to match: X.Y.Z
+    pattern='[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'
+
+    # List of files to replace
+    files=(                   \
+        "CMakeLists.txt"      \
+        "docs/source/conf.py" \
+    )
+
+    # Replace version numbers in files
+    for file in ${files[@]}; do
+        replace "${pattern}" "${version}" "${file}"
+        [[ $? -ne 0 ]] && exitWithError "${file}"
+        echo "GCClassic version updated to ${version} in ${file}"
+    done
+
+    #========================================================================
+    # Update version number and date in CHANGELOG.md
+    #========================================================================
+
+    # Pattern to match: "[Unreleased] - TBD"
+    pattern='\[.*Unreleased.*\].*'
+    date=$(date -Idate)
+
+    # List of files to replace
+    files=(                                                          \
+        "CHANGELOG.md"                                               \
+        "src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/CHANGELOG.md" \
+    )
+
+    # Replace version numbers in files
+    for file in ${files[@]}; do
+	replace "${pattern}" "\[${version}\] - ${date}" "${file}"
+        [[ $? -ne 0 ]] && exitWithError "${file}"
+        echo "GCClassic version updated to ${version} in ${file}"
+    done
+
+    # Return to the starting directory
+    cd "${thisDir}"
+}
+
+# ---------------------------------------------------------------------------
+
+# Expect 1 argument, or exit with error
+if [[ $# -ne 1 ]]; then
+    echo "Usage: ./changeVersionNumbers.sh VERSION"
+    exit 1
+fi
+
+# Replace version numbers
+main "${1}"
+
+# Return status
+exit $?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] -- TBD
+### Added
+- Script `.release/changeVersionNumbers.sh` to change version numbers before a new GCHP release
+
 ## [14.2.2] - 2023-10-23
 ### Changed
 - Updated GEOS-Chem submodule to 14.2.2


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This PR adds a script that changes the GCHP version numbers in the following files:

  - CMakeLists.txt
  - docs/source/conf.py
  - CHANGELOG.md
  - src/GEOS-Chem/CHANGELOG.md

This is a convenience script for use by the GCST before new versions are released.

### Expected changes

This is a no-diff update.

### Related Github Issue(s)

- https://github.com/geoschem/HEMCO/pull/242
- https://github.com/geoschem/GCClassic/pull/46