### PR TITLE
Merge no-diff-to-benchmark updates into the 14.3.0 development stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Avoid semicolon in `CMAKE_ Fortran_FLAGS` variable when additional flags are passed to `cmake`
+
 ## [14.2.3] - 2023-12-01
 ### Added
 - Script `.release/changeVersionNumbers.sh` to change version numbers before a new GCHP release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ ecbuild_declare_project()
 find_package(MPI REQUIRED COMPONENTS C CXX Fortran)
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-  list(APPEND CMAKE_Fortran_FLAGS "-ffree-line-length-none")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
 endif()
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This PR requests to merge the dev/no-diff-to-benchmark branch into the dev/14.3.0 branch. This includes updates from the following PRs:

- https://github.com/geoschem/GCHP/pull/334

Hashes will be updated for the various PRs described in 

- https://github.com/geoschem/geos-chem/pull/2106

### Expected changes
All of these updates have been verified to be zero-diff w/r/t the fullchem benchmark simulation vs GEOS-Chem 14.2.3.