### PR TITLE
Fix bug in advection when using raw GMAO meteorology files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Now print container name being read by ExtData when `CAP.EXTDATA` is set to `DEBUG` in `logging.yml`
 
+### Fixed
+- Fixed bug where SPHU used to construct PLE for advection was vertically inverted if using raw GMAO meteorology files
+
 ## [14.3.0] - 2024-02-07
 ### Added
 - Added capability for TOMAS simulations in GCHP

--- a/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
+++ b/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
@@ -686,11 +686,21 @@ module GCHPctmEnv_GridComp
       ! Also compute dry pressures if using dry pressure in advection
       if ( use_total_air_pressure_in_advection < 1 ) then
 
-         call calculate_ple(PS1_IMPORT, DryPLE0_EXPORT, SPHU1_IMPORT )
+         call calculate_ple(          &
+              PS=PS1_IMPORT,          &
+              PLE=DryPLE0_EXPORT,     &
+              SPHU=SPHU1_IMPORT,      &
+              topDownMet=meteorology_vertical_index_is_top_down )
+
          DryPLE0_EXPORT = 100.0d0 * DryPLE0_EXPORT
          DryPLE0_EXPORT = DryPLE0_EXPORT(:,:,LM:0:-1)
 
-         call calculate_ple(PS2_IMPORT, DryPLE1_EXPORT, SPHU2_IMPORT )
+         call calculate_ple(          &
+              PS=PS2_IMPORT,          &
+              PLE=DryPLE1_EXPORT,     &
+              SPHU=SPHU2_IMPORT,      &
+              topDownMet=meteorology_vertical_index_is_top_down )
+
          DryPLE1_EXPORT = 100.0d0 * DryPLE1_EXPORT
          DryPLE1_EXPORT = DryPLE1_EXPORT(:,:,LM:0:-1)
 
@@ -973,12 +983,13 @@ module GCHPctmEnv_GridComp
 !
 ! !INTERFACE:
 !
-   subroutine calculate_ple(PS, PLE, SPHU)
+   subroutine calculate_ple(PS, PLE, SPHU, topDownMet )
 !
 ! !INPUT PARAMETERS:
 !
       real(r4), intent(in)           :: PS(:,:)     ! Surface pressure [hPa]
       real(r4), intent(in), OPTIONAL :: SPHU(:,:,:) ! Specific humidity [kg/kg]
+      logical,  intent(in), OPTIONAL :: topDownMet  ! True if meteorology level 1 is TOA
 !
 ! !INPUT PARAMETERS:
 !
@@ -1070,26 +1081,57 @@ module GCHPctmEnv_GridComp
          js = lbound(PS,2)
          je = ubound(PS,2)
          LM = size  (SPHU,3)
-         do J=js,je
-         do I=is,ie
 
-            ! Start with TOA pressure
-            PSDry = AP(LM+1)
+         if ( topDownMet ) then
 
-            ! Stack up dry delta-P to get surface dry pressure
-            do L=1,LM
-               PEdge_Bot = AP(L  ) + ( BP(L  ) * dble(PS(I,J)) )
-               PEdge_Top = AP(L+1) + ( BP(L+1) * dble(PS(I,J)) )
-               PSDry = PSDry &
-                       + ( ( PEdge_Bot - Pedge_Top ) * ( 1.d0 - SPHU(I,J,L) ) )
+           do J=js,je
+           do I=is,ie
+
+              ! Start with TOA pressure
+              PSDry = AP(LM+1)
+
+              ! Stack up dry delta-P to get surface dry pressure
+              ! Vertically flip humidity if using top-down meteorology (raw GMAO files)
+              do L=1,LM
+                 PEdge_Bot = AP(L  ) + ( BP(L  ) * dble(PS(I,J)) )
+                 PEdge_Top = AP(L+1) + ( BP(L+1) * dble(PS(I,J)) )
+                 PSDry = PSDry &
+                         + ( ( PEdge_Bot - Pedge_Top ) * ( 1.d0 - SPHU(I,J,LM-L+1) ) )
+              enddo
+
+              ! Work back up from the surface to get dry level edges
+              do L=1,LM+1
+                 PLE(I,J,L) = AP(L) + ( BP(L) * dble(PSDry) )
+              enddo
+
+           enddo
+           enddo
+
+         else
+
+            do J=js,je
+            do I=is,ie
+
+               ! Start with TOA pressure
+               PSDry = AP(LM+1)
+
+               ! Stack up dry delta-P to get surface dry pressure
+               do L=1,LM
+                  PEdge_Bot = AP(L  ) + ( BP(L  ) * dble(PS(I,J)) )
+                  PEdge_Top = AP(L+1) + ( BP(L+1) * dble(PS(I,J)) )
+                  PSDry = PSDry &
+                          + ( ( PEdge_Bot - Pedge_Top ) * ( 1.d0 - SPHU(I,J,L) ) )
+               enddo
+
+               ! Work back up from the surface to get dry level edges
+               do L=1,LM+1
+                  PLE(I,J,L) = AP(L) + ( BP(L) * dble(PSDry) )
+               enddo
+            enddo
             enddo
 
-            ! Work back up from the surface to get dry level edges
-            do L=1,LM+1
-               PLE(I,J,L) = AP(L) + ( BP(L) * dble(PSDry) )
-            enddo
-         enddo
-         enddo
+         endif
+
       endif
 
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes a bug in dry pressures passed to advection when using raw GMAO meteorology files. The moisture used for the conversion from 2D surface moist pressure to 3D level edge dry pressure needs to be vertically flipped when using raw GMAO input files.

This was a bug introduced in 14.0 when reverting to using dry air pressure in advection. The prior implementation of using dry air pressure in advection (13.3 and prior) did not yet have the 13.4 update to run with raw GMAO files. GCHP benchmarking uses only processed meteorology files which are vertically flipped relative to the raw files and therefore this bug went under the radar until now.

### Expected changes

This is a no diff update for GCHP benchmarking. See the GitHub issue linked below for expected differences in runs using raw GMAO meteorology input files.

### Reference(s)

None

### Related Github Issue(s)

https://github.com/geoschem/GCHP/issues/386
