### PR TITLE
Now use short submodule names in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,36 +1,36 @@
-[submodule "src/MAPL"]
+[submodule "MAPL"]
 	path = src/MAPL
 	url = https://github.com/geoschem/MAPL
-[submodule "src/GMAO_Shared"]
+[submodule "GMAO_Shared"]
 	path = src/GMAO_Shared
 	url = https://github.com/geoschem/GMAO_Shared
 [submodule "ESMA_cmake"]
 	path = ESMA_cmake
 	url = https://github.com/geoschem/ESMA_cmake
-[submodule "src/gFTL-shared"]
+[submodule "gFTL-shared"]
 	path = src/gFTL-shared
 	url = https://github.com/geoschem/gFTL-shared.git
-[submodule "src/FMS"]
+[submodule "FMS"]
 	path = src/FMS
 	url = https://github.com/geoschem/FMS.git
-[submodule "src/GCHP_GridComp/FVdycoreCubed_GridComp"]
+[submodule "FVdycoreCubed_GridComp"]
 	path = src/GCHP_GridComp/FVdycoreCubed_GridComp
 	url = https://github.com/geoschem/FVdycoreCubed_GridComp.git
-[submodule "src/GCHP_GridComp/GEOSChem_GridComp/geos-chem"]
+[submodule "geos-chem"]
 	path = src/GCHP_GridComp/GEOSChem_GridComp/geos-chem
 	url = https://github.com/geoschem/geos-chem.git
-[submodule "src/GCHP_GridComp/HEMCO_GridComp/HEMCO"]
+[submodule "HEMCO"]
 	path = src/GCHP_GridComp/HEMCO_GridComp/HEMCO
 	url = https://github.com/geoschem/HEMCO.git
-[submodule "src/yaFyaml"]
+[submodule "yaFyaml"]
 	path = src/yaFyaml
 	url = https://github.com/geoschem/yaFyaml.git
-[submodule "src/pFlogger"]
+[submodule "pFlogger"]
 	path = src/pFlogger
 	url = https://github.com/geoschem/pFlogger.git
-[submodule "docs/source/geos-chem-shared-docs"]
+[submodule "geos-chem-shared-docs"]
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git
-[submodule "src/GCHP_GridComp/Cloud-J"]
+[submodule "Cloud-J"]
 	path = src/GCHP_GridComp/Cloud-J
 	url = https://github.com/geoschem/Cloud-J

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,9 @@
 [submodule "src/pFlogger"]
 	path = src/pFlogger
 	url = https://github.com/geoschem/pFlogger.git
-[submodule "docs/geos-chem-shared-docs"]
+[submodule "docs/source/geos-chem-shared-docs"]
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git
-[submodule "src/GCHP_GridComp/GEOSChem_GridComp/Cloud-J"]
+[submodule "src/GCHP_GridComp/Cloud-J"]
 	path = src/GCHP_GridComp/Cloud-J
 	url = https://github.com/geoschem/Cloud-J

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed bug where SPHU used to construct PLE for advection was vertically inverted if using raw GMAO meteorology files
+- Fixed submodule names (`geos-chem-shared-docs`, `Cloud-J`) to be consistent with the declared `path` in .gitmodules`
 
 ## [14.3.0] - 2024-02-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Now print container name being read by ExtData when `CAP.EXTDATA` is set to `DEBUG` in `logging.yml`
 
+### Changed
+- Now use short names for submodules (i.e. without the path) in `.gitmodules`
+
 ### Fixed
 - Fixed bug where SPHU used to construct PLE for advection was vertically inverted if using raw GMAO meteorology files
-- Fixed submodule names (`geos-chem-shared-docs`, `Cloud-J`) to be consistent with the declared `path` in .gitmodules`
 
 ## [14.3.0] - 2024-02-07
 ### Added


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gchp.readthedocs.io/en/latest/reference/CONTRIBUTING.html)

### Describe the update
This is a minor update that fixes some incorrect submodule names in the `.gitmodules` file.  We have changed:
```console
[submodule "src/MAPL"]
[submodule "src/GMAO_Shared"]
[submodule "ESMA_cmake"]
[submodule "src/gFTL-shared"]
[submodule "src/FMS"]
[submodule "src/GCHP_GridComp/FVdycoreCubed_GridComp"]
[submodule "src/GCHP_GridComp/GEOSChem_GridComp/geos-chem"]
[submodule "src/GCHP_GridComp/HEMCO_GridComp/HEMCO"]
[submodule "src/yaFyaml"]
[submodule "src/pFlogger"]
[submodule "docs/geos-chem-shared-docs"]
[submodule "src/GCHP_GridComp/GEOSChem_GridComp/Cloud-J"]
```
to
```console
[submodule "MAPL"]
[submodule "GMAO_Shared"]
[submodule "ESMA_cmake"]
[submodule "gFTL-shared"]
[submodule "FMS"]
[submodule "FVdycoreCubed_GridComp"]
[submodule "geos-chem"]
[submodule "HEMCO"]
[submodule "yaFyaml"]
[submodule "pFlogger"]
[submodule "geos-chem-shared-docs"]
[submodule "Cloud-J"]
```
This "future-proofs" the submodule names in case a submodule is moved to a different path.

### Expected changes
This is a zero-diff update,

### Related Github Issue(s)
NOTE: This PR should be merged immediately after:
- https://github.com/geoschem/geos-chem/pull/2154
- https://github.com/geoschem/cloud-j/pull/2

