### PR TITLE
Expand GCHP advection diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Now print container name being read by ExtData when `CAP.EXTDATA` is set to `DEBUG` in `logging.yml`
 - Added new pre-processer setting GCHP_WRAPPER for use in submodules
+- Added PLEadv export to FV3 submodule for inclusion in GCHP HISTORY.rc files
 
 ### Changed
 - Now use short names for submodules (i.e. without the path) in `.gitmodules`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed bug where SPHU used to construct PLE for advection was vertically inverted if using raw GMAO meteorology files
+- Fixed bug in UpwardsMassFlux diagnostic that was causing all values to be zero
 
 ## [14.3.0] - 2024-02-07
 ### Added

--- a/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
+++ b/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
@@ -944,10 +944,10 @@ module GCHPctmEnv_GridComp
       end if
 
       ! Set vertical motion diagnostic if enabled in HISTORY.rc
+      call MAPL_GetPointer(EXPORT, UpwardsMassFlux, 'UpwardsMassFlux', &
+           NotFoundOK=.TRUE., RC=STATUS)
+      _VERIFY(STATUS)
       if (associated(UpwardsMassFlux)) then
-         call MAPL_GetPointer(EXPORT, UpwardsMassFlux, 'UpwardsMassFlux', &
-                              RC=STATUS)
-         _VERIFY(STATUS)
          call lgr%debug('Calculating diagnostic export UpwardsMassFlux')
 
          ! Get vertical mass flux


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR contains the changelog updates for GCHP advection diagnostic updates going into FV3 and GEOS-Chem submodules. It also fixes a bug in setting the UpwardsMassFlux flux diagnostic that was causing it to be all zeros.

**This PR should be merged in at the same time as the PRs for those submodules (see list of PRs below).**

### Expected changes

This is a no diff update. The three new diagnostic collections in GEOS-Chem are all off by default.

### Reference(s)

None

### Required submodule PRs

- https://github.com/geoschem/geos-chem/pull/2199
- https://github.com/geoschem/FVdycoreCubed_GridComp/pull/8
