### PR TITLE
Add GCHP_WRAPPER cpp definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Now print container name being read by ExtData when `CAP.EXTDATA` is set to `DEBUG` in `logging.yml`
+- Added new pre-processer setting GCHP_WRAPPER for use in submodules
 
 ### Changed
 - Now use short names for submodules (i.e. without the path) in `.gitmodules`

--- a/src/GCHP_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Set cmake logicals needed for subprojects
 #---------------
 set(FV_PRECISION           R8    ) # FV3 precision is R8
+set(GCHP_WRAPPER           TRUE  ) # GCHP model configuration
 set(CLOUDJ_EXTERNAL_CONFIG TRUE  ) # Not Cloud-J standalone
 set(HEMCO_EXTERNAL_CONFIG  TRUE  ) # Not HEMCO standalone
 set(GC_EXTERNAL_CONFIG     TRUE  ) # Not GEOS-Chem Classic


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR adds new pre-processor definition `GCHP_WRAPPER` to GCHP. It is needed for use in Cloud-J and can be used for other submodules in the future. The name matches the analogous pre-processor switch called `GCCLASSIC_WRAPPER` that is in GEOS-Chem Classic.

**This update is a required for use with Cloud-J PR https://github.com/geoschem/Cloud-J/pull/2 and GEOS-Chem PR https://github.com/geoschem/geos-chem/pull/2154.**

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github PRs

- https://github.com/geoschem/Cloud-J/pull/2
- https://github.com/geoschem/geos-chem/pull/2154
