### PR TITLE
Fixed CMake error to prevent KPP standalone being built in carbon sim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed dry mass flux derivation in GCHPctmEnv when using mass flux imports
 - Fixed UpwardsMassFlux sign to make positive represent upwards direction
+- Fixed logic error in `src/CMakeLists.txt` that attempted to build the KPP standalone for the carbon simulation (see geoschem/GCClassic #78)
 
 ## [14.5.0] - 2024-11-08
 ### Added

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,17 +65,20 @@ set_target_properties(${EXE_FILE_NAME}
 # 2. Specify the location of the main program
 # 3. Specify libraries that the main program depends on
 # 4. Store the binary exectuable file in the bin folder (pre-install)
+# 5. If not fullchem or custom mechanism, prevent executable from being built
 #
 # At present build KPP standalone only for fullchem or custom mechanisms.
+#
+# This should now fix the issue reported by @msulprizio in:
+#   https://github.com/geoschem/GCClassic/issues/78
 #-----------------------------------------------------------------------------
+set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
+  "Default name for the KPP standalone executable file")
+mark_as_advanced(KPPSA_FILE_NAME)
+add_executable(${KPPSA_FILE_NAME}
+  GCHP_GridComp/GEOSChem_GridComp/geos-chem/KPP/standalone/kpp_standalone.F90
+)
 if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
-  set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
-    "Default name for the KPP standalone executable file")
-  mark_as_advanced(KPPSA_FILE_NAME)
-
-  add_executable(${KPPSA_FILE_NAME}
-    GCHP_GridComp/GEOSChem_GridComp/geos-chem/KPP/standalone/kpp_standalone.F90
-  )
   target_link_libraries(${KPPSA_FILE_NAME}
     PUBLIC
     KPPStandalone
@@ -83,6 +86,11 @@ if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
   set_target_properties(${KPPSA_FILE_NAME}
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+else()
+  set_target_properties(${KPPSA_FILE_NAME}
+    PROPERTIES
+    EXCLUDE_FROM_ALL TRUE
   )
 endif()
 
@@ -123,7 +131,12 @@ foreach(INSTALL_PATH ${COMBINED_INSTALL_DIRS})
       # Installation path is a GEOS-Chem run directory,
       # Therefore we will install the executable there.
       install(TARGETS ${EXE_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
-      install(TARGETS ${KPPSA_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
+
+      # Only install KPP standalone for fullchem/custom mechanisms.
+      # See: htps://github.com/geoschem/GCClassic/issues/78
+      if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
+        install(TARGETS ${KPPSA_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
+      endif()
     endif()
 
 endforeach()


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR fixes the error described by @msulprizio in https://github.com/geoschem/GCClassic/issues/78.  We have reworked the logic in the `src/CMakeLists.txt` to disable building the KPP standalone executable for simulations other than fullchem & custom, even if the CMake commands are given separately.

### Expected changes:
These commands now configure GCHP correctly:
```console
cmake ../CodeDir
cmake . -DMECH=custom -DRUNDIR=..
```

### Related Github Issue

- https://github.com/geoschem/GCClassic/issues/78
- https://github.com/geoschem/GCClassic/pull/79
