### PR TITLE
Bump jinja2 to 3.1.5 as suggested by Dependabot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Bumped `jinja2` to version 3.1.5 in `docs/requirements.txt` to fix a security issue
+
 ## [14.5.1] - 2025-01-10
 ### Added
 - Added code to `src/CMakeLists.txt` to build & install the KPP standalone executable when `fullchem` or `custom` mechanisms are selected

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,4 +12,4 @@ sphinxcontrib-bibtex==2.6.2
 sphinx-autobuild==2021.3.14
 recommonmark==0.7.1
 docutils==0.20.1
-jinja2==3.1.4
+jinja2==3.1.5


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
We have updated the version of jinja2 (needed for ReadTheDocs) from 3.1.4 to 3.1.5, to fix a security issue.  This was suggested by the GitHub Dependabot service.

### Expected changes
This is a zero-diff update.  It only affects the Python packages used for ReadTheDocs.