### PR TITLE
Increased execution memory for GCHP cloud benchmarks from 80 GB to 120 GB

### DIFF
--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -87,7 +87,7 @@ jobs:
                 `"\"timePeriod\": \"${TIME_PERIOD}\","`
                 `"\"tag\": \"${COMMIT_NAME}\","`
                 `"\"numCores\": \"${NUM_CORES}\","`
-                `"\"memory\": \"80000\","` 
+                `"\"memory\": \"120000\","`
                 `"\"resolution\": \"${RESOLUTION}\","`
                 `"\"sendEmailNotification\": \"true\""`
               `"},"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Increased execution memory for GCHP cloud benchmarks from 80 to 120 GB in `.github/workflows/cloud-benchmarking-workflow.yml`
+
 ## [14.5.1] - 2025-01-10
 ### Added
 - Added code to `src/CMakeLists.txt` to build & install the KPP standalone executable when `fullchem` or `custom` mechanisms are selected


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #470.  We have increased the execution memory setting from 80 GB to 120 GB in GCHP cloud benchmarks.  The CEDS emissions at 0.1 degree resolution have increased the memory footprint of the GCHP fullchem benchmark simulations.

### Expected changes
This is a zero-diff update.  It should now allow GCHP 1-month and 1-hour benchmarks on AWS to proceed without failing (and having to manually resubmit with more memory).

### Related Github Issue
- Closes #470