### PR TITLE
Do not build KPP-Standalone executable unless specifically requested at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Changed
 - Bumped `jinja2` to version 3.1.5 in `docs/requirements.txt` to fix a security issue
+- Changed the build sequence so that the KPP-Standalone is only built when configuring with `-DKPPSA=y`
 
 ## [14.5.1] - 2025-01-10
 ### Added

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,8 @@ set_target_properties(${EXE_FILE_NAME}
 )
 
 #-----------------------------------------------------------------------------
+# If GCHP has been configured with -DKPPSA=y, then:
+#
 # Define the KPP standalone executable:
 # 1. Specify a cache variable with the default target name
 # 2. Specify the location of the main program
@@ -72,26 +74,28 @@ set_target_properties(${EXE_FILE_NAME}
 # This should now fix the issue reported by @msulprizio in:
 #   https://github.com/geoschem/GCClassic/issues/78
 #-----------------------------------------------------------------------------
-set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
-  "Default name for the KPP standalone executable file")
-mark_as_advanced(KPPSA_FILE_NAME)
-add_executable(${KPPSA_FILE_NAME}
-  GCHP_GridComp/GEOSChem_GridComp/geos-chem/KPP/standalone/kpp_standalone.F90
-)
-if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
-  target_link_libraries(${KPPSA_FILE_NAME}
-    PUBLIC
-    KPPStandalone
-  )
-  set_target_properties(${KPPSA_FILE_NAME}
-    PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-else()
-  set_target_properties(${KPPSA_FILE_NAME}
-    PROPERTIES
-    EXCLUDE_FROM_ALL TRUE
-  )
+if (${KPPSA})
+  set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
+    "Default name for the KPP standalone executable file")
+  mark_as_advanced(KPPSA_FILE_NAME)
+  add_executable(${KPPSA_FILE_NAME}
+    GCHP_GridComp/GEOSChem_GridComp/geos-chem/KPP/standalone/kpp_standalone.F90
+    )
+  if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
+    target_link_libraries(${KPPSA_FILE_NAME}
+      PUBLIC
+      KPPStandalone
+      )
+    set_target_properties(${KPPSA_FILE_NAME}
+      PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+      )
+  else()
+    set_target_properties(${KPPSA_FILE_NAME}
+      PROPERTIES
+      EXCLUDE_FROM_ALL TRUE
+      )
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------

--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -16,6 +16,9 @@ set(LUO_WETDEP OFF CACHE BOOL
 set(FASTJX OFF CACHE BOOL
   "Switch to use legacy FAST-JX photolysis in GEOS-Chem"
 )
+set(KPPSA OFF CACHE BOOL
+  "Switch to build the KPP-Standalone Box Model"
+)
 
 # Local variables
 set(GC_EXTERNAL_CONFIG      TRUE)
@@ -147,3 +150,4 @@ gc_pretty_print(VARIABLE RRTMG IS_BOOLEAN)
 gc_pretty_print(VARIABLE GTMM IS_BOOLEAN)
 gc_pretty_print(VARIABLE LUO_WETDEP IS_BOOLEAN)
 gc_pretty_print(VARIABLE FASTJX IS_BOOLEAN)
+gc_pretty_print(VARIABLE KPPSA IS_BOOLEAN)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR adds CMake updates so that the KPP-Standalone executable will not be built unless the user configures with the `-DKPPSA=y` option.

### Expected changes
This is a zero-diff update 

### Related Github Issue
- Must be merged with https://github.com/geoschem/geos-chem/pull/2712