### PR TITLE
GCHP 14.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.6.2] - 2025-06-12
+### Changed
+- Updated GEOS-Chem submodule to 14.6.2
+
 ## [14.6.1] - 2025-05-29
 ### Added
 - Added ReadTheDocs documentation updates for GCHP 14.6.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.13)
 project (gchp_ctm
-  VERSION 14.6.1
+  VERSION 14.6.2
   LANGUAGES Fortran CXX C
 )
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2024, GEOS-Chem Support Team'
 author = 'GEOS-Chem Support Team'
 
 # The full version, including alpha/beta/rc tags
-release = '14.6.1'
+release = '14.6.2'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)
Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR seeks to merge the release/14.6.2 branch into main in anticipation of the GCHP 14.6.1 release.

The release/14.6.2 branch contains

- Commits from the dev/no-diff-to-benchmark branch
- Documentation updates from the docs/dev branch.
- Updated version numbers to 14.6.2 in the usual places.
- Updated GEOS-Chem submodule to 14.6.2