### PR TITLE
Adjoint fix for computing mass fluxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [NOT YET RELEASED] - TBD
+### Fixed
+- Fixed bug in GCHP adjoint code to compute mass fluxes after first run
+
 ## [14.6.2] - 2025-06-12
 ### Changed
 - Updated GEOS-Chem submodule to 14.6.2

--- a/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
+++ b/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
@@ -842,6 +842,10 @@ module GCHPctmEnv_GridComp
       real(r8), pointer, dimension(:,:,:) :: UCr8      => null()
       real(r8), pointer, dimension(:,:,:) :: VCr8      => null()
 
+#ifdef ADJOINT
+      logical, save :: firstRun = .true.
+#endif
+
       !=====================================
       ! prepare_massflux_exports starts here
       !=====================================
@@ -931,14 +935,17 @@ module GCHPctmEnv_GridComp
          UCr8  = dble(UC)
          VCr8  = dble(VC)
          
-#ifdef ADJOINT
+#ifndef ADJOINT
+         ! Calculate mass fluxes and courant numbers
+         call fv_computeMassFluxes(UCr8, VCr8, PLE, &
+              MFX_EXPORT, MFY_EXPORT, &
+              CX_EXPORT, CY_EXPORT, dt)
+#else
          if (.not. firstRun) THEN
-#endif
             ! Calculate mass fluxes and courant numbers
             call fv_computeMassFluxes(UCr8, VCr8, PLE, &
-                                      MFX_EXPORT, MFY_EXPORT, & 
-                                      CX_EXPORT, CY_EXPORT, dt)
-#ifdef ADJOINT
+                 MFX_EXPORT, MFY_EXPORT, &
+                 CX_EXPORT, CY_EXPORT, dt)
          endif
          firstRun = .false.
 #endif


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren, on behalf of Kay Suselj (JPL) (@kaysuselj)
Institution: Harvard University

### Describe the update

Fix bug in GCHP adjoint-only code to skip computing mass fluxes the first time GCHPctmEnv run is called.

### Expected changes

None. This update is in GCHP-adjoint only code.

### Reference(s)

None

### Related Github Issue

This PR supercedes https://github.com/geoschem/GCHP/pull/489 so that we do not need to rebase and push to Kay's main branch.
