### PR TITLE
Add -DSANITIZE compiler option to check for memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [NOT YET RELEASED] - TBD
+### Added
+- Added `-DSANITIZE` option for use with GNU Fortran compiler to check for memory leaks
+
 ### Fixed
 - Fixed bug in GCHP adjoint code to compute mass fluxes after first run
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,18 @@ if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
 endif()
 
+# Add code sanitation options (GNU Fortran only), e.g. memory leak checking
+set(SANITIZE OFF CACHE BOOL
+    "Switch to turn on code sanitization (i.e. identify memory leaks and similar conditions)"
+)
+if(${SANITIZE})
+  if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -fsanitize=leak -fsanitize=address -fsanitize=undefined")
+  else()
+    message( FATAL_ERROR "The SANITIZE option is only defined for GNU Fortran.")
+  endif()
+endif()
+
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
 
 # Add the directory with gchp_ctm's source code


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie lundgren
Institution: Harvard University

### Describe the update

This PR adds the `SANITIZE` compiler option to perform sanitization checks at run-time, such as identifying memory leaks. Flags included are the same as used for the sanitize option in GC-Classic:

- -fsanitize=leak
- -fsanitize=address
- -fsanitize=undefined.

To use the option, include `-DSANITIZE` when compiling GCHP. See the [GNU documentation](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html) for more information on these flags.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue

None
