### PR TITLE
Add connectivity from GEOS-Chem to advection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added R4 exports in GCHPctmEnv for diagnostics since R8 to R4 conversion in MAPL 2.55 History is broken
 - Added submodule for GFE (Goddard-Fortran-Ecosystem) which includes GMAO libraries yafYaml, pFlogger, gFTL, gFTL-shared, fArgParse, and pFUnit as its own submodules
+- Added connectivity from GEOS-Chem to FV3 dynamics to pass DELP_DRY in GEOS-Chem restart file to advection for restart file species mass conservation
 
 ### Changed
 - Changed minimum CMake version from 3.13 to 3.24

--- a/src/GCHP_GridComp/GCHP_GridCompMod.F90
+++ b/src/GCHP_GridComp/GCHP_GridCompMod.F90
@@ -219,6 +219,12 @@ contains
                                   SRC_ID = ADV,                &
                                   __RC__ )
 
+      CALL MAPL_AddConnectivity ( GC,                           &
+                                  SHORT_NAME = (/ 'DELPDRY' /), &
+                                  DST_ID = ADV,                 &
+                                  SRC_ID = CHEM,                &
+                                  __RC__ )
+
       CALL MAPL_TerminateImport    ( GC,                         &
                                      SHORT_NAME = (/'TRADV'/), &
                                      CHILD = ADV,                &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR adds a new connectivity between GCHP gridded components to facilitate mass conservation of restart file species mass in the first timestep. New GEOS-Chem export `DELPDRY`, which is set to the delta pressure from the GEOS-Chem restart file, is passed to a new import of the same name in the dynamics component. Two companion PRs are required, within which are updates to apply a pressure ratio scaling to restart file species mixing ratios prior to running offline advection. This ensures mass conservation of species mass in the restart file, and fixes issue https://github.com/geoschem/geos-chem/issues/2536.

There is also a new config option in GCHP.rc to enable printing global mass proxies of air and species #1 every timestep following advection. The config option is called `PRINT_MASS_IN_ADVECTION` with value 0 corresponding to false and 1 corresponding to true. The default value in all run directories is 0.

**Companion PRs required for this update:**
https://github.com/geoschem/FVdycoreCubed_GridComp/pull/11
https://github.com/geoschem/geos-chem/pull/3062

### Expected changes

This update will cause small differences in GCHP for all simulations.

### Reference(s)

None

### Related Github Issue

Closes https://github.com/geoschem/geos-chem/issues/2536
