### PR TITLE
Update ESMA_cmake submodule with fixes for GNU/Intel Fortran flags for certain chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated docs to include library requirement udunits2 and additional information about stretched grid parameters
 - Updated `lint-ci-workflows` to run on `main` and `dev/*` branches
 - Updated badges on `README.md` and `docs/source/index.rst`
+- Updated submodule ESMA_cmake for GNU Fortran compiler compatibility with CPUs returning processor description INTEL
 
 ### Fixed
 - Fixed security issues in GitHub Actions that caused the `lint-ci-workflows` action to fail


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR updates submodule [ESMA_cmake](https://github.com/geoschem/esma_cmake) to include pull request [Fix process description detection issue with EmeraldRapids #8](https://github.com/geoschem/ESMA_cmake/pull/8). It prevents failure when using GNU and Intel Fortran compilers with chips that return INTEL (all caps) as processor, e.g. Emerald Rapids.

### Expected changes

This is a no-diff update.

### Reference(s)

None

### Related Github Issue

closes https://github.com/geoschem/GCHP/issues/517
