### PR TITLE
Fix vertical flipping c720 fields with processed met

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed security issues in GitHub Actions that caused the `lint-ci-workflows` action to fail
+- Fixed vertical flipping bug in GCHPctmEnv when using C720 fields with GEOS-FP processed data
 
 ### Removed
 - Removed individual submodules for yafYaml, pFlogger, and gFTL-shared since now located in new submodule GFE

--- a/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
+++ b/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
@@ -48,8 +48,9 @@ module GCHPctmEnv_GridComp
    integer, parameter :: r8     = 8
    integer, parameter :: r4     = 4
    
-   logical :: adv_meteorology_flux_is_top_down
-   logical :: adv_meteorology_humidity_is_top_down
+   logical :: met_mass_flux_is_top_down
+   logical :: met_wind_is_top_down
+   logical :: met_humidity_is_top_down
    integer :: use_total_air_pressure_in_advection
    integer :: correct_mass_flux_for_humidity
    
@@ -157,14 +158,6 @@ module GCHPctmEnv_GridComp
       call MAPL_AddImportSpec(gc, &
                               SHORT_NAME='PS2', &
                               LONG_NAME='pressure_at_surface_after_advection',&
-                              UNITS='hPa', &
-                              DIMS=MAPL_DimsHorzOnly, &
-                              VLOCATION=MAPL_VLocationEdge, &
-                              RC=STATUS)
-      _VERIFY(STATUS)
-      call MAPL_AddImportSpec(gc, &
-                              SHORT_NAME='PS2', &
-                              LONG_NAME='pressure_at_surface_after_advection', &
                               UNITS='hPa', &
                               DIMS=MAPL_DimsHorzOnly, &
                               VLOCATION=MAPL_VLocationEdge, &
@@ -520,46 +513,55 @@ module GCHPctmEnv_GridComp
       ! Get whether meteorology vertical index is top down (native fields)
       ! or bottom up (GEOS-Chem processed fields)
       ! -----------------------------------------------------------------
-      ! Flux (wind or mass flux)
-      call ESMF_ConfigGetAttribute( &
-           CF,                                             &
-           value=adv_meteorology_flux_is_top_down,         &
-           label='MET_ADVECTION_FLUX_IS_TOP_DOWN:',        &
-           Default=.false.,                                &
-           __RC__ )
-      if (adv_meteorology_flux_is_top_down) then
-         msg='Configured to expect ''top-down'' meteorological data'// &
-             ' from ''ExtData'' for flux used in advection (wind or mass flux)'
+
+      ! Get vertical direction of flux that will be used
+      if ( import_mass_flux_from_extdata) then
+
+         ! Get vertical direction of mass flux import
+         call ESMF_ConfigGetAttribute( CF,        &
+              value=met_mass_flux_is_top_down,    &
+              label='MET_MASS_FLUX_IS_TOP_DOWN:', &
+              Default=.true., __RC__ )
+         if (met_mass_flux_is_top_down) then
+            msg='Configured to expect ''top-down'' mass flux data from ''ExtData'''
+         else
+            msg='Configured to expect ''bottom-up'' mass flux data data from ''ExtData'''
+         end if
+
       else
-         msg='Configured to expect ''bottom-up'' meteorological'// &
-             ' data from ''ExtData'' for flux used in advection (wind or mass flux)'
-      end if
+
+         ! Get vertical direction of wind import
+         call ESMF_ConfigGetAttribute( CF,       &
+           value=met_wind_is_top_down,           &
+           label='MET_WIND_IS_TOP_DOWN:',        &
+           Default=.false., __RC__ )
+         if (met_wind_is_top_down) then
+            msg='Configured to expect ''top-down'' wind data from ''ExtData'''
+         else
+            msg='Configured to expect ''bottom-up'' wind data from ''ExtData'''
+         end if
+         call lgr%info(trim(msg))
+
+      endif
       call lgr%info(trim(msg))
 
-      ! Humidity
-      call ESMF_ConfigGetAttribute( &
-           CF,                                             &
-           value=adv_meteorology_humidity_is_top_down,      &
-           label='MET_HUMIDITY_IS_TOP_DOWN:',     &
-           Default=.false.,                                &
-           __RC__ )
-      if (adv_meteorology_humidity_is_top_down) then
-         msg='Configured to expect ''top-down'' meteorological data'// &
-             ' from ''ExtData'' for humidity used in advection'
+      ! Get vertical direction of humidity
+      call ESMF_ConfigGetAttribute( CF,                &
+           value=met_humidity_is_top_down, &
+           label='MET_HUMIDITY_IS_TOP_DOWN:',          &
+           Default=.false., __RC__ )
+      if (met_humidity_is_top_down) then
+         msg='Configured to expect ''top-down'' humidity data from ''ExtData'''
       else
-         msg='Configured to expect ''bottom-up'' meteorological'// &
-             ' data from ''ExtData'' for humidity used in advection'
+         msg='Configured to expect ''bottom-up'' humidity data from ''ExtData'''
       end if
       call lgr%info(trim(msg))
 
       ! Get whether to use total or dry air pressure in advection
-      ! -----------------------------------------------------------------
-      call ESMF_ConfigGetAttribute( &
-                               CF,                                             &
-                               value=use_total_air_pressure_in_advection,      &
-                               label='USE_TOTAL_AIR_PRESSURE_IN_ADVECTION:',   &
-                               Default=0,                                      &
-                               __RC__ )
+      call ESMF_ConfigGetAttribute( CF,                    &
+           value=use_total_air_pressure_in_advection,      &
+           label='USE_TOTAL_AIR_PRESSURE_IN_ADVECTION:',   &
+           Default=0, __RC__ )
       if ( use_total_air_pressure_in_advection > 0 ) then
          msg='Configured to use total air pressure in advection'
       else
@@ -568,13 +570,10 @@ module GCHPctmEnv_GridComp
       call lgr%info(trim(msg))
 
       ! Get whether to correct mass flux for humidity (convert total to dry)
-      ! -----------------------------------------------------------------
-      call ESMF_ConfigGetAttribute( &
-                               CF,                                             &
-                               value=correct_mass_flux_for_humidity,           &
-                               label='CORRECT_MASS_FLUX_FOR_HUMIDITY:',        &
-                               Default=1,                                      &
-                               __RC__ )
+      call ESMF_ConfigGetAttribute( CF,              &
+           value=correct_mass_flux_for_humidity,     &
+           label='CORRECT_MASS_FLUX_FOR_HUMIDITY:',  &
+           Default=1, __RC__ )
       if ( correct_mass_flux_for_humidity > 0 ) then
          msg='Configured to correct native mass flux (if using) for humidity'
       else
@@ -798,8 +797,7 @@ module GCHPctmEnv_GridComp
          call calculate_ple(          &
               PS=PS1_IMPORT,          &
               PLE=DryPLE0_EXPORT,     &
-              SPHU=SPHU1_IMPORT,      &
-              topDownMet=adv_meteorology_humidity_is_top_down )
+              SPHU=SPHU1_IMPORT )
 
          DryPLE0_EXPORT = 100.0d0 * DryPLE0_EXPORT
          DryPLE0_EXPORT = DryPLE0_EXPORT(:,:,LM:0:-1)
@@ -807,8 +805,7 @@ module GCHPctmEnv_GridComp
          call calculate_ple(          &
               PS=PS2_IMPORT,          &
               PLE=DryPLE1_EXPORT,     &
-              SPHU=SPHU2_IMPORT,      &
-              topDownMet=adv_meteorology_humidity_is_top_down )
+              SPHU=SPHU2_IMPORT )
 
          DryPLE1_EXPORT = 100.0d0 * DryPLE1_EXPORT
          DryPLE1_EXPORT = DryPLE1_EXPORT(:,:,LM:0:-1)
@@ -893,7 +890,7 @@ module GCHPctmEnv_GridComp
 
       ! Set export as copy of import casted to real8 and set vertical index
       ! as top-down (level 1 corresponds to TOA)
-      if (adv_meteorology_humidity_is_top_down) then
+      if (met_humidity_is_top_down) then
          SPHU0_EXPORT = dble(SPHU1_IMPORT)
       else
          SPHU0_EXPORT(:,:,:) = dble(SPHU1_IMPORT(:,:,LM:1:-1))
@@ -1017,7 +1014,7 @@ module GCHPctmEnv_GridComp
          call MAPL_GetPointer(IMPORT, CY_IMPORT, 'CYC',  RC=STATUS)
          _VERIFY(STATUS)
 
-         if (adv_meteorology_flux_is_top_down) then
+         if (met_mass_flux_is_top_down) then
             MFX_EXPORT =  dble(MFX_IMPORT(:,:,:))
             MFY_EXPORT =  dble(MFY_IMPORT(:,:,:))
             CX_EXPORT  =  dble(CX_IMPORT(:,:,:))
@@ -1053,7 +1050,7 @@ module GCHPctmEnv_GridComp
          _VERIFY(STATUS)
          
          ! Copy imports to local arrays so that vertical index is top down
-         if (adv_meteorology_flux_is_top_down) then
+         if (met_wind_is_top_down) then
             UC(:,:,:) = UA_IMPORT(:,:,:)
             VC(:,:,:) = VA_IMPORT(:,:,:)
          else
@@ -1148,13 +1145,12 @@ module GCHPctmEnv_GridComp
 !
 ! !INTERFACE:
 !
-   subroutine calculate_ple(PS, PLE, SPHU, topDownMet )
+   subroutine calculate_ple(PS, PLE, SPHU )
 !
 ! !INPUT PARAMETERS:
 !
       real(r4), intent(in)           :: PS(:,:)     ! Surface pressure [hPa]
       real(r4), intent(in), OPTIONAL :: SPHU(:,:,:) ! Specific humidity [kg/kg]
-      logical,  intent(in), OPTIONAL :: topDownMet  ! True if meteorology level 1 is TOA
 !
 ! !INPUT PARAMETERS:
 !
@@ -1247,7 +1243,7 @@ module GCHPctmEnv_GridComp
          je = ubound(PS,2)
          LM = size  (SPHU,3)
 
-         if ( topDownMet ) then
+         if ( met_humidity_is_top_down ) then
 
            do J=js,je
            do I=is,ie
@@ -1256,7 +1252,7 @@ module GCHPctmEnv_GridComp
               PSDry = AP(LM+1)
 
               ! Stack up dry delta-P to get surface dry pressure
-              ! Vertically flip humidity if using top-down meteorology (raw GMAO files)
+              ! Vertically flip humidity if SPHU import vertical direction is down
               do L=1,LM
                  PEdge_Bot = AP(L  ) + ( BP(L  ) * dble(PS(I,J)) )
                  PEdge_Top = AP(L+1) + ( BP(L+1) * dble(PS(I,J)) )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren 
Institution: Harvard University

### Describe the update

This PR incorporates new entries in GCHP config file GCHP.rc that are brought in with a companion PR in the GEOS-Chem repository (https://github.com/geoschem/geos-chem/pull/3131). This fixes a problem vertically flipping met-fields when using GEOS-FP C720 files (top-down) with GEOS-FP processed 0.25x0.625 files (bottom-up).

### Expected changes

This update does not impact benchmarking. It is zero diff except for the specific case of using GEOS-FP C720 files with GEOS-FP processed fields.

### Reference(s)

None

### Related Github Issue

https://github.com/geoschem/GCHP/issues/527
**Companion PR required: https://github.com/geoschem/geos-chem/pull/3131**
