### PR TITLE
Compiler option for GCHP load balance in chemistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This file documents all notable changes to the GCHP wrapper repository starting 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.7.1] - Unreleased
+### Added
+- Added build option MPI_LOAD_BALANCE to enable MPI load balancing in GEOS-Chem chemistry
+
+### Changed
+- Changed default settings to use MPI load balancing in chemistry to speed up GCHP runs unless KPP standalone is enabled
+
 ## [14.7.0] - 2026-02-06
 ### Added
 - Added R4 exports in GCHPctmEnv for diagnostics since R8 to R4 conversion in MAPL 2.55 History is broken

--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -19,6 +19,9 @@ set(FASTJX OFF CACHE BOOL
 set(KPPSA OFF CACHE BOOL
   "Switch to build the KPP-Standalone Box Model"
 )
+set(MPI_LOAD_BALANCE ON CACHE BOOL
+  "Switch to apply MPI load balance in chemistry if using GCHP"
+)
 
 # Local variables
 set(GC_EXTERNAL_CONFIG      TRUE)
@@ -48,6 +51,7 @@ target_compile_definitions(GEOSChemBuildProperties INTERFACE
   $<$<STREQUAL:${TOMAS_BINS},40>:TOMAS40>
   $<$<BOOL:${LUO_WETDEP}>:LUO_WETDEP>
   $<$<BOOL:${FASTJX}>:FASTJX>
+  $<$<BOOL:${MPI_LOAD_BALANCE}>:MPI_LOAD_BALANCE>
 )
 
 target_link_libraries(GEOSChemBuildProperties INTERFACE
@@ -151,3 +155,4 @@ gc_pretty_print(VARIABLE GTMM IS_BOOLEAN)
 gc_pretty_print(VARIABLE LUO_WETDEP IS_BOOLEAN)
 gc_pretty_print(VARIABLE FASTJX IS_BOOLEAN)
 gc_pretty_print(VARIABLE KPPSA IS_BOOLEAN)
+gc_pretty_print(VARIABLE MPI_LOAD_BALANCE IS_BOOLEAN)

--- a/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
+++ b/src/GCHP_GridComp/GEOSChem_GridComp/CMakeLists.txt
@@ -23,6 +23,11 @@ set(MPI_LOAD_BALANCE ON CACHE BOOL
   "Switch to apply MPI load balance in chemistry if using GCHP"
 )
 
+# Turn off load balancing if KPP standalone is on
+if(${KPPSA})
+  set(MPI_LOAD_BALANCE OFF)
+endif()
+
 # Local variables
 set(GC_EXTERNAL_CONFIG      TRUE)
 set(CLOUDJ_EXTERNAL_CONFIG  TRUE) # Not Cloud-J standalone
@@ -43,7 +48,8 @@ add_subdirectory(geos-chem EXCLUDE_FROM_ALL)
 # Configure build properties for GEOS-Chem
 target_compile_definitions(GEOSChemBuildProperties INTERFACE
   ESMF_ EXTERNAL_GRID NC_HAS_COMPRESSION MODEL_GCHPCTM MODEL_GCHP
-  $<$<BOOL:${USE_REAL8}>:USE_REAL8> $<$<BOOL:${RRTMG}>:RRTMG>
+  $<$<BOOL:${USE_REAL8}>:USE_REAL8>
+  $<$<BOOL:${RRTMG}>:RRTMG>
   $<$<BOOL:${ADJOINT}>:ADJOINT>
   $<$<BOOL:${REVERSE_OPERATORS}>:REVERSE_OPERATORS> 
   $<$<BOOL:${TOMAS}>:TOMAS>
@@ -51,6 +57,7 @@ target_compile_definitions(GEOSChemBuildProperties INTERFACE
   $<$<STREQUAL:${TOMAS_BINS},40>:TOMAS40>
   $<$<BOOL:${LUO_WETDEP}>:LUO_WETDEP>
   $<$<BOOL:${FASTJX}>:FASTJX>
+  $<$<BOOL:${KPPSA}>:KPPSA>
   $<$<BOOL:${MPI_LOAD_BALANCE}>:MPI_LOAD_BALANCE>
 )
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

Add CMake option for turning MPI load balancing on/off. It will be on by default. Turn off by building with:
`-DMPI_LOAD_BALANCE=n`

There is a companion PR with this update:
https://github.com/geoschem/geos-chem/pull/3015

### Expected changes

MPI_LOAD_BALANCE will appear in the messages during the configure stage indicating whether it is on or off. GCHP chemistry will be faster with it on (default). I find the benchmark simulation to be 20% faster on the Harvard Cannon cluster using 96 cores.

### Reference(s)

None

### Related Github Issue

- https://github.com/geoschem/GCHP/issues/235
- https://github.com/geoschem/geos-chem/pull/3015

