### PR TITLE
Make ExtData2G available as beta in transport tracers simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Changed default settings to use MPI load balancing in chemistry to speed up GCHP runs unless KPP standalone is enabled
+- Turned off vertical flipping of top-down meteorology in GCHPctmEnv if using ExtData2G
 
 ## [14.7.0] - 2026-02-06
 ### Added

--- a/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
+++ b/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
@@ -471,6 +471,7 @@ module GCHPctmEnv_GridComp
       integer                    :: comm
       character(len=ESMF_MAXSTR) :: COMP_NAME
       character(len=ESMF_MAXSTR) :: msg
+      logical                    :: use_extdata2g
       type(ESMF_Config)          :: CF
       type(ESMF_Grid)            :: esmfGrid
       type(ESMF_VM)              :: VM
@@ -509,53 +510,65 @@ module GCHPctmEnv_GridComp
       ! -----------------------------------------------------------------
       call ESMF_GridCompGet(GC, GRID=esmfGrid, rc=STATUS)
       _VERIFY(STATUS)
+
+      ! Get whether using ExtData (first generation) or ExtData 2G
+      ! -----------------------------------------------------------------
+      call ESMF_ConfigGetAttribute(CF, value=use_extdata2g, &
+           label='USE_EXTDATA2G:', Default=.false., __RC__ )
       
       ! Get whether meteorology vertical index is top down (native fields)
-      ! or bottom up (GEOS-Chem processed fields)
+      ! or bottom up (GEOS-Chem processed fields) in import from MAPL ExtData.
+      ! If using ExtData2G then fields are already flipped to bottom up
+      ! within MAPL.
       ! -----------------------------------------------------------------
-
-      ! Get vertical direction of flux that will be used
-      if ( import_mass_flux_from_extdata) then
-
-         ! Get vertical direction of mass flux import
-         call ESMF_ConfigGetAttribute( CF,        &
-              value=met_mass_flux_is_top_down,    &
-              label='MET_MASS_FLUX_IS_TOP_DOWN:', &
-              Default=.true., __RC__ )
-         if (met_mass_flux_is_top_down) then
-            msg='Configured to expect ''top-down'' mass flux data from ''ExtData'''
-         else
-            msg='Configured to expect ''bottom-up'' mass flux data data from ''ExtData'''
-         end if
-
+      if ( use_extdata2g ) then
+         met_mass_flux_is_top_down = .false.
+         met_wind_is_top_down = .false.
+         met_humidity_is_top_down = .false.
+         call lgr%info('Using MAPL ExtData2G; all ''top-down'' meteorological data is flipped to ''bottom-up'' within MAPL.')
       else
+         if ( import_mass_flux_from_extdata) then
 
-         ! Get vertical direction of wind import
-         call ESMF_ConfigGetAttribute( CF,       &
-           value=met_wind_is_top_down,           &
-           label='MET_WIND_IS_TOP_DOWN:',        &
-           Default=.false., __RC__ )
-         if (met_wind_is_top_down) then
-            msg='Configured to expect ''top-down'' wind data from ''ExtData'''
+            ! Get vertical direction of mass flux import
+            call ESMF_ConfigGetAttribute( CF,        &
+                 value=met_mass_flux_is_top_down,    &
+                 label='MET_MASS_FLUX_IS_TOP_DOWN:', &
+                 Default=.true., __RC__ )
+            if (met_mass_flux_is_top_down) then
+               msg='Configured to expect ''top-down'' mass flux data from ''ExtData'''
+            else
+               msg='Configured to expect ''bottom-up'' mass flux data data from ''ExtData'''
+            end if
+
          else
-            msg='Configured to expect ''bottom-up'' wind data from ''ExtData'''
+
+            ! Get vertical direction of wind import
+            call ESMF_ConfigGetAttribute( CF,   &
+                 value=met_wind_is_top_down,    &
+                 label='MET_WIND_IS_TOP_DOWN:', &
+                 Default=.false., __RC__ )
+            if (met_wind_is_top_down) then
+               msg='Configured to expect ''top-down'' wind data from ''ExtData'''
+            else
+               msg='Configured to expect ''bottom-up'' wind data from ''ExtData'''
+            end if
+
+         endif
+         call lgr%info(trim(msg))
+
+         ! Get vertical direction of humidity
+         call ESMF_ConfigGetAttribute( CF,       &
+              value=met_humidity_is_top_down,    &
+              label='MET_HUMIDITY_IS_TOP_DOWN:', &
+              Default=.false., __RC__ )
+         if (met_humidity_is_top_down) then
+            msg='Configured to expect ''top-down'' humidity data from ''ExtData'''
+         else
+            msg='Configured to expect ''bottom-up'' humidity data from ''ExtData'''
          end if
          call lgr%info(trim(msg))
 
       endif
-      call lgr%info(trim(msg))
-
-      ! Get vertical direction of humidity
-      call ESMF_ConfigGetAttribute( CF,                &
-           value=met_humidity_is_top_down, &
-           label='MET_HUMIDITY_IS_TOP_DOWN:',          &
-           Default=.false., __RC__ )
-      if (met_humidity_is_top_down) then
-         msg='Configured to expect ''top-down'' humidity data from ''ExtData'''
-      else
-         msg='Configured to expect ''bottom-up'' humidity data from ''ExtData'''
-      end if
-      call lgr%info(trim(msg))
 
       ! Get whether to use total or dry air pressure in advection
       call ESMF_ConfigGetAttribute( CF,                    &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR, combined with https://github.com/geoschem/MAPL/pull/41 and https://github.com/geoschem/geos-chem/pull/3233, makes MAPL 2.59 module ExtData2G available for use with the transport tracer simulation in GCHP. ExtData2G is the next generation of MAPL ExtData, the software package from NASA GMAO that handles file data imports in GCHP. It is being released in this version as beta. Please read the list of caveats below before use. These messages are also communicated during transport tracer run directory creation.

By default ExtData2G is off. Users may turn it on within `setCommonRunSettings.sh` by setting `Use_ExtData2G` to `true`. The primary difference between ExtData and ExtData2G that affects users is the retirement of input configuration file `ExtData.rc`, replaced by new file `extdata.yaml` in yaml format. For transport tracer simulations both files are automatically copied to the run directory during run directory creation.

There are several caveats with this update:
1. `extdata.yaml` is only available for the transport tracers simulation, and it is pre-configured only for MERRA2. If using a different meteorology source then you will need to edit the file, or wait for a later GCHP version in which this is automatic during run directory creation.
2. Config file `setCommonRunSettings.sh` includes automatic update of several configuration entries in `ExtData.rc`  based on other settings, and these updates are not yet ported to automatically update `extdata.yaml`. More specifically, you must manually edit the read frequency of pressure and temperature if using grid resolution above C180 due to the change in timesteps, and if you add mass fluxes and Courant numbers to the list of imports in `extdata.yaml` then you will need to manually change the scaling if the timestep changes. These changes will be automatic in a future version of GCHP.
4. NASA GMAO prepared an [ExtData2G User Guide](https://github.com/GEOS-ESM/MAPL/wiki/ExtData-Next-Generation---User-Guide#451-mask-functions) which details how to read and configure `extdata.yaml`. This resource will be referenced from GCHP ReadTheDocs. 

### Expected changes

This is a no diff update for GEOS-Chem benchmarking because ExtData2G is off by default and is released in GCHP only as beta.

Switching between ExtData and ExtData2G causes very small differences. Here is an example of differences for Rn222 in the restart file (REAL8) after a 1-day transport tracer simulation. We suspect the differences are due to one or more precision changes in MAPL ExtData code but this has not been verified. The diffs are so small that they are undetectable for nearly all diagnostics (REAL4) after a 1-day run.

<img width="762" height="896" alt="Screenshot 2026-03-18 at 3 20 28 PM" src="https://github.com/user-attachments/assets/c6fa2273-9c70-4e7d-b7ec-72344a1e1240" />

<img width="795" height="1032" alt="Screenshot 2026-03-18 at 2 44 07 PM" src="https://github.com/user-attachments/assets/108de0e7-6a52-4c94-b110-5998e948c360" />

### Reference(s)

[ExtData2G User Guide](https://github.com/GEOS-ESM/MAPL/wiki/ExtData-Next-Generation---User-Guide#451-mask-functions)

### Related Github Issues/PRs

Required pull requests:
- https://github.com/geoschem/MAPL/pull/41
- https://github.com/geoschem/geos-chem/pull/3233


 
