### PR TITLE
Specify the latest version of GitHub Actions to avoid Node20.js deprecation warnings

### DIFF
--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -36,7 +36,7 @@ jobs:
           mkdir -p ${{ github.workspace }}
       
        # For now both use Spot instances -- may need to update to use on demand
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/lint-ci-workflows.yml
+++ b/.github/workflows/lint-ci-workflows.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Checkout code
         with:
           persist-credentials: false
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Installs Python 3.x
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/spack-deployment-workflow.yml
+++ b/.github/workflows/spack-deployment-workflow.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     container: continuumio/miniconda3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'stale'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [14.7.1] - Unreleased
 ### Added
-- Added build option MPI_LOAD_BALANCE to enable MPI load balancing in GEOS-Chem chemistry
+- Added build option `MPI_LOAD_BALANCE` to enable MPI load balancing in GEOS-Chem chemistry
 
 ### Changed
 - Changed default settings to use MPI load balancing in chemistry to speed up GCHP runs unless KPP standalone is enabled
+- Updated GitHub Actions to the latest versions
 
 ## [14.7.0] - 2026-02-06
 ### Added


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

GitHub Actions is retiring Node20.js from all of its runners in June 2026:

>gnu (Debug)Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Therefore we have updated all of the GitHub Actions workflow files to check out the latest version of each action rather than pegging to a specific version. 

| Old version | New version |
| ----- | ---- |
| actions/checkout@v4 | actions/checkout@v6 |
| actions/setup-python@v4 | actions/setup-python@v6 |
| actions/stale@v5 | actions/stale@v10 |

### Expected changes
- This is a no-diff-to-benchmark update that will only affect GitHub actions.
- This will allow our GitHub Actions to proceed as normal after GitHub removes Node20.js support in June.
- This will make our setup more future-proof against further GitHub Actions system changes.