### PR TITLE
Fix bug in UpwardsMassFlux diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated HEMCO submodule to 3.12.1
 - Turned off vertical flipping of top-down meteorology in GCHPctmEnv if using ExtData2G
 
+### Fixed
+- Fixed zero UpwardsMassFlux diagnostic
+
 ## [14.7.0] - 2026-02-06
 ### Added
 - Added R4 exports in GCHPctmEnv for diagnostics since R8 to R4 conversion in MAPL 2.55 History is broken

--- a/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
+++ b/src/GCHP_GridComp/GCHPctmEnv_GridComp/GCHPctmEnv_GridCompMod.F90
@@ -325,15 +325,6 @@ module GCHPctmEnv_GridComp
                               VLOCATION=MAPL_VLocationCenter, &
                               RC=STATUS)
       _VERIFY(STATUS)
-      call MAPL_AddExportSpec(gc, &
-                              SHORT_NAME='UpwardsMassFlux', &
-                              LONG_NAME='upward_mass_flux_of_air', &
-                              UNITS='kg m-2 s-1', &
-                              PRECISION=ESMF_KIND_R8, &
-                              DIMS=MAPL_DimsHorzVert, &
-                              VLOCATION=MAPL_VLocationEdge, &
-                              RC=STATUS)
-      _VERIFY(STATUS)
 
       ! Add the same exports as R4 as a work-around to a MAPL 2.55 History
       ! bug where R8 cannot be converted to R4 for output (ewl, 5/28/25)
@@ -410,7 +401,7 @@ module GCHPctmEnv_GridComp
                               RC=STATUS)
       _VERIFY(STATUS)
       call MAPL_AddExportSpec(gc, &
-                              SHORT_NAME='UpwardsMassFlux_R4', &
+                              SHORT_NAME='UpwardsMassFlux', &
                               LONG_NAME='upward_mass_flux_of_air', &
                               UNITS='kg m-2 s-1', &
                               DIMS=MAPL_DimsHorzVert, &
@@ -976,8 +967,7 @@ module GCHPctmEnv_GridComp
       real,     pointer, dimension(:,:,:) :: VA_IMPORT  => null()
 
       ! Pointer to diagnostic export
-      real(r8), pointer, dimension(:,:,:) :: UpwardsMassFlux => null()
-      real(r4), pointer, dimension(:,:,:) :: UpwardsMassFlux_R4 => null()
+      real(r4), pointer, dimension(:,:,:) :: UpwardsMassFlux => null()
 
       ! Pointers to local arrays
       real,     pointer, dimension(:,:,:) :: UC        => null()
@@ -1135,7 +1125,6 @@ module GCHPctmEnv_GridComp
       CY_IMPORT       => null()
       UA_IMPORT       => null()
       VA_IMPORT       => null()
-      UpwardsMassFlux => null()
       UC              => null()
       VC              => null()
       UCr8            => null()
@@ -1146,6 +1135,7 @@ module GCHPctmEnv_GridComp
       MFY_R4_EXPORT      => null()
       CX_R4_EXPORT       => null()
       CY_R4_EXPORT       => null()
+      UpwardsMassFlux    => null()
 
       _RETURN(ESMF_SUCCESS)
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes a bug introduced in 14.7.0 where the `UpwardsMassFlux' diagnostic in GCHP was all zeros. This occurred because the new REAL4 export created was not actually set. The old REAL8 export remained and was set instead.

As part of this update, I removed the old REAL8 export since it is no longer needed. I also changed the name of the REAL4 export back to what it was before the change (`UpwardsMassFlux` rather than `UpwardsMassFlux_R4`). The REAL4 values are extracted directly from FV3 without need to modify that repository.

**This update requires two submodule pull requests:**
- https://github.com/geoschem/geos-chem/pull/3276
- https://github.com/geoschem/FVdycoreCubed_GridComp/pull/13.

### Expected changes

Diagnostic `UpwardsMassFlux_R4` is now `UpwardsMassFlux` and does not contain all zeros.

### Reference(s)

None

### Related Github Issue

https://github.com/geoschem/GCHP/issues/544
