### PR TITLE
Changing default model resolution from C24 to C90

### DIFF
--- a/docs/source/getting-started/quick-start.rst
+++ b/docs/source/getting-started/quick-start.rst
@@ -218,6 +218,17 @@ You therefore need to run it to actually apply the settings:
    $ vim setCommonRunSettings.sh           # edit simulation settings here
    $ ./setCommonRunSettings.sh             # applies the updated settings
 
+.. attention::
+   Note that as of GCHP version 14.8.0, the default grid resolution 
+   is C90, approximately equal to 1x1 degrees. C90 is the minimum 
+   recommended grid resolution for most scientific applications, 
+   but is more computationally expensive and can take longer to 
+   run than coarser resolutions.
+   C24 (formerly the default) and C48 are still available, and are 
+   recommended for testing purposes. For a more detailed explanation of 
+   the different grid resolutions, see the :ref:`GCHP Horizontal Grids
+   <gchp_hgrids>` supplemental guide.
+
 Simulation start date is set in :file:`cap_restart`.  Run directories
 come with this file filled in based on date of the initial restart
 file in subdirectory :file:`Restarts`.  You can change the start date

--- a/docs/source/supplement/horizontal-grids.rst
+++ b/docs/source/supplement/horizontal-grids.rst
@@ -69,6 +69,17 @@ The table below shows some common cubed-sphere configurations.
      - 223,948,800
      - 0.125° x 0.15625°
 
+A horizontal grid resolution of C90 is generally the minimum recommended 
+for most scientific applications, as it is known that representation of 
+transport processes begins to degrade below this threshold. As of GCHP 
+14.8.0, the default grid resolution is C90. C24 and C48 resolutions 
+are still available, and are sufficient for some applications, such as 
+testing new model configurations and feature implementations.
+
+Switching to a higher horizontal grid resolution will likely result in 
+increased computational cost and longer run times. Think carefully about
+your specific requirements before submitting new jobs.
+
 See our :ref:`stretched-grid` chapter for information about how
 you can stretch one of the grid faces to achieve extra-fine resolution
 over a target location.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Helena McDonald
Institution: Harvard University

### Describe the update

Changes to run directory creation script to update default model resolution for all runs to c90; removes the separate logic for GEOS_IT. Changes to RTD documentation to alert users to new default resolution and its reasoning, as well as inside setCommonRunSettings.sh.

### Expected changes

No diff to benchmark. 

### Related Github Issue

Corresponds [to GCHP issue #553](https://github.com/geoschem/GCHP/issues/553#issue-4666550455). 
