### PR TITLE
Documentation update for switching GCHP default resolution to c90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Changed
 - Updated Python packages needed for ReadTheDocs
+- Updated default GCHP resolution in createRunDir.sh from c24 for MERAA2/GEOS-FP and c30 for GEOS-IT to c90 in all cases. 
 
 ## [14.7.1] - 2026-04-14
 ### Added

--- a/docs/source/getting-started/quick-start.rst
+++ b/docs/source/getting-started/quick-start.rst
@@ -218,6 +218,15 @@ You therefore need to run it to actually apply the settings:
    $ vim setCommonRunSettings.sh           # edit simulation settings here
    $ ./setCommonRunSettings.sh             # applies the updated settings
 
+..attention::
+   Note that as of GCHP 14.8.0 the default grid resolution is C90. If you 
+   are using an older version of GCHP, the default grid resolution is C24.
+   C90 is approximately equal to 1x1 degrees and is recommended for most 
+   scientific outputs. As it is known that representation of some transport 
+   processes degrades at coarser resolutions, C48 and C24 are recommended 
+   primarily for testing and debugging purposes. See :ref:`horizontal-grids` 
+   for more information about different GCHP grid resolutions.
+
 Simulation start date is set in :file:`cap_restart`.  Run directories
 come with this file filled in based on date of the initial restart
 file in subdirectory :file:`Restarts`.  You can change the start date

--- a/docs/source/getting-started/quick-start.rst
+++ b/docs/source/getting-started/quick-start.rst
@@ -222,7 +222,7 @@ You therefore need to run it to actually apply the settings:
    When creating a GCHP run directory, the default grid resolution in 
    configuration file setCommonRunSettings.sh is set to C90. C90 has a
    resolution of approximately 110km globally, similar to the average 
-   resolution of a 1x1 degree lat-lon grid, and is recommended for most
+   resolution of a 1x1 degree lat-lon grid, and is sufficient for most
    scientific outputs. See :ref:`horizontal-grids` for more information
    about different GCHP grid resolutions and notes on selecting the 
    appropriate resolution for your runs.

--- a/docs/source/getting-started/quick-start.rst
+++ b/docs/source/getting-started/quick-start.rst
@@ -218,14 +218,14 @@ You therefore need to run it to actually apply the settings:
    $ vim setCommonRunSettings.sh           # edit simulation settings here
    $ ./setCommonRunSettings.sh             # applies the updated settings
 
-..attention::
-   Note that as of GCHP 14.8.0 the default grid resolution is C90. If you 
-   are using an older version of GCHP, the default grid resolution is C24.
-   C90 is approximately equal to 1x1 degrees and is recommended for most 
-   scientific outputs. As it is known that representation of some transport 
-   processes degrades at coarser resolutions, C48 and C24 are recommended 
-   primarily for testing and debugging purposes. See :ref:`horizontal-grids` 
-   for more information about different GCHP grid resolutions.
+.. attention::
+   When creating a GCHP run directory, the default grid resolution in 
+   configuration file setCommonRunSettings.sh is set to C90. C90 has a
+   resolution of approximately 110km globally, similar to the average 
+   resolution of a 1x1 degree lat-lon grid, and is recommended for most
+   scientific outputs. See :ref:`horizontal-grids` for more information
+   about different GCHP grid resolutions and notes on selecting the 
+   appropriate resolution for your runs.
 
 Simulation start date is set in :file:`cap_restart`.  Run directories
 come with this file filled in based on date of the initial restart

--- a/docs/source/supplement/horizontal-grids.rst
+++ b/docs/source/supplement/horizontal-grids.rst
@@ -69,6 +69,16 @@ The table below shows some common cubed-sphere configurations.
      - 223,948,800
      - 0.125° x 0.15625°
 
+As of GCHP 14.8.0, the default grid resolution is C90, which is approximately
+equal to 1x1 degrees. As there are known issues with representation of some transport 
+processes at coarser resolutions, C48 and C24 are recommended primarily for testing and 
+debugging purposes. It is encouraged to use C90 or greater for most scientific outputs.
+
+Switching from C24 or C48 to C90 or higher will require some changes to your run configuration, 
+as the computational cost of running GCHP increases with grid resolution. As a result, runs may 
+require more cores, nodes, memory, and wall time. Users are encouraged to think carefully about 
+their run's needs and available resources when choosing a grid resolution.
+
 See our :ref:`stretched-grid` chapter for information about how
 you can stretch one of the grid faces to achieve extra-fine resolution
 over a target location.

--- a/docs/source/supplement/horizontal-grids.rst
+++ b/docs/source/supplement/horizontal-grids.rst
@@ -71,8 +71,10 @@ The table below shows some common cubed-sphere configurations.
 
 As of GCHP 14.8.0, the default grid resolution is C90, which is approximately
 equal to 1x1 degrees. As there are known issues with representation of some transport 
-processes at coarser resolutions, C48 and C24 are recommended primarily for testing and 
-debugging purposes. It is encouraged to use C90 or greater for most scientific outputs.
+processes at coarser model resolutions [:cite:`Strahan_Polansky._2006`], C48 and C24 are 
+recommended primarily for testing and debugging purposes. It is encouraged to use C90 or 
+greater for most scientific outputs, unless you are confident these issues will not affect 
+your results. 
 
 Switching from C24 or C48 to C90 or higher will require some changes to your run configuration, 
 as the computational cost of running GCHP increases with grid resolution. As a result, runs may 

--- a/docs/source/supplement/horizontal-grids.rst
+++ b/docs/source/supplement/horizontal-grids.rst
@@ -69,17 +69,61 @@ The table below shows some common cubed-sphere configurations.
      - 223,948,800
      - 0.125° x 0.15625°
 
-As of GCHP 14.8.0, the default grid resolution is C90, which is approximately
-equal to 1x1 degrees. As there are known issues with representation of some transport 
-processes at coarser model resolutions [:cite:`Strahan_Polansky._2006`], C48 and C24 are 
-recommended primarily for testing and debugging purposes. It is encouraged to use C90 or 
-greater for most scientific outputs, unless you are confident these issues will not affect 
-your results. 
+As of GCHP 14.8.0, the default grid resolution is C90. Users are encouraged to 
+think carefully about their run's needs and available resources when choosing a 
+grid resolution. Higher-resolution simulations provide a more faithful
+representation of transport :cite:`Strahan_Polansky._2006`, as the model can better
+resolve nonlinearities and heterogeneity, albeit at greater computational expense. 
+Current GCHP applications commonly span within C48 to C360, and lower resolutions are
+generally recommended for testing and debugging over scientific output. Determing a
+"sufficient" model resolution is highly dependent on your exact research question. 
 
-Switching from C24 or C48 to C90 or higher will require some changes to your run configuration, 
-as the computational cost of running GCHP increases with grid resolution. As a result, runs may 
-require more cores, nodes, memory, and wall time. Users are encouraged to think carefully about 
-their run's needs and available resources when choosing a grid resolution.
+Switching from C24/30/48 to C90 or higher will require some changes to your run 
+configuration, as the computational cost of running GCHP increases with grid 
+resolution. To aid with this, the below table provides rough timing estimates for 
+GCHP runs at different resolutions. These exact timings are specific to the Harvard
+Cannon cluster, but can illustrate roughly the expected change in run duration as 
+resolution is increased.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Resolution
+     - Simulation length
+     - Nodes/Cores
+     - Memory
+     - Run duration (dd:hh:mm:ss)
+   * - C24
+     - 1 week
+     - 96/2
+     - 360GB (3.8GB per CPU-core)
+     - 00:02:37:43
+   * - C48
+     - 1 week
+     - 96/2
+     - 
+     - 
+   * - C90
+     - 1 week
+     - 96/2
+     - 
+     - 
+   * - C24
+     - 1 month
+     - 96/2
+     - 
+     - 
+   * - C48
+     - 1 month
+     - 96/2
+     - 
+     - 
+   * - C90
+     - 1 month
+     - 96/2
+     - 
+     - 
+
 
 See our :ref:`stretched-grid` chapter for information about how
 you can stretch one of the grid faces to achieve extra-fine resolution

--- a/docs/source/supplement/horizontal-grids.rst
+++ b/docs/source/supplement/horizontal-grids.rst
@@ -69,13 +69,12 @@ The table below shows some common cubed-sphere configurations.
      - 223,948,800
      - 0.125° x 0.15625°
 
-As of GCHP 14.8.0, the default grid resolution is C90. Users are encouraged to 
+The default GCHP grid resolution is C90. Users are encouraged to 
 think carefully about their run's needs and available resources when choosing a 
 grid resolution. Higher-resolution simulations provide a more faithful
 representation of transport :cite:`Strahan_Polansky._2006`, as the model can better
 resolve nonlinearities and heterogeneity, albeit at greater computational expense. 
-Current GCHP applications commonly span within C48 to C360, and lower resolutions are
-generally recommended for testing and debugging over scientific output. Determing a
+Current GCHP applications commonly span within C48 to C360. Determing a
 "sufficient" model resolution is highly dependent on your exact research question. 
 
 Switching from C24/30/48 to C90 or higher will require some changes to your run 

--- a/docs/source/supplement/horizontal-grids.rst
+++ b/docs/source/supplement/horizontal-grids.rst
@@ -80,50 +80,7 @@ generally recommended for testing and debugging over scientific output. Determin
 
 Switching from C24/30/48 to C90 or higher will require some changes to your run 
 configuration, as the computational cost of running GCHP increases with grid 
-resolution. To aid with this, the below table provides rough timing estimates for 
-GCHP runs at different resolutions. These exact timings are specific to the Harvard
-Cannon cluster, but can illustrate roughly the expected change in run duration as 
-resolution is increased.
-
-.. list-table::
-   :header-rows: 1
-
-   * - Resolution
-     - Simulation length
-     - Nodes/Cores
-     - Memory
-     - Run duration (dd:hh:mm:ss)
-   * - C24
-     - 1 week
-     - 96/2
-     - 360GB (3.8GB per CPU-core)
-     - 00:02:37:43
-   * - C48
-     - 1 week
-     - 96/2
-     - 
-     - 
-   * - C90
-     - 1 week
-     - 96/2
-     - 
-     - 
-   * - C24
-     - 1 month
-     - 96/2
-     - 
-     - 
-   * - C48
-     - 1 month
-     - 96/2
-     - 
-     - 
-   * - C90
-     - 1 month
-     - 96/2
-     - 
-     - 
-
+resolution. 
 
 See our :ref:`stretched-grid` chapter for information about how
 you can stretch one of the grid faces to achieve extra-fine resolution


### PR DESCRIPTION
### Name and Institution (Required)

Name: Helena McDonald
Institution: Harvard University

### Describe the update

Updates to Quickstart guide and horizontal grids supplemental guide to note the default resolution has switched to c90. 

### Expected changes

None. 

### Related Github Issue

GCHP issue #553. 
