### PR TITLE
Request 96 vcpus for AWS instance used for GCHP benchmark runs

### DIFF
--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -84,7 +84,12 @@ jobs:
       - name: Trigger Step Function
         env:
           # Set config options for aws cli
-          NUM_CORES: 62
+          # Require 96 vcpus in AWS instance used for benchmarking. See
+          # gc-cloud-infrastructure for actual number of cores used for the
+          # GCHP benchmark runs. Due to performance issues with multi-threading
+          # on AWS, GCHP benchmarks are limited to using only physical cores,
+          # which may be half the number of vcpus available in the instance.
+          NUM_CORES: 96
           EC2_TYPE: SPOT # SPOT or DEMAND
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `fetch-tags: true` to `checkout@v4` in the GitHub Actions file `.github/workflows/cloud-benchmarking-workflow.yml`
 - Added MAPL3 code blocks for developing MAPL3 compatibility
 
+### Changed
+- Require 96 vcpus for AWS instance used for benchmarking
+
 ## [14.7.1] - 2026-04-14
 ### Added
 - Added build option `MPI_LOAD_BALANCE` to enable MPI load balancing in GEOS-Chem chemistry


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR changes the number of vcpus required for the AWS instance used for GCHP benchmark runs. This updates is so that GCHP and GC-Classic use the same number of cores. This enables an apples-to-apples timing comparison. Previously, in 14.7.0, GCHP used 30 cores while GC-Classic used 62.

Note that request of 96 vcpus does not mean 96 cores will be used for the GCHP benchmark runs. We are limiting the GCHP benchmark runs to physical cores (less than equal to number of vcpus) only because performance is degraded when using multi-threading on AWS. The number of physical cores in an AWS instance is often half of the number of vcpus. See the gc-cloud-infrastructure repository for where the actual number of cores used for GCHP runs is set. In 14.8.0 we will use 48 physical cores for GCHP.

**This update should be merged at the same time as the following PRs:**
- https://github.com/geoschem/GCClassic/pull/112
- https://github.com/geoschem/gc-cloud-infrastructure/pull/64

### Expected changes

This is a no diff update for all simulations. 

### Reference(s)

None

### Related Github Issue

None

